### PR TITLE
Com 2112

### DIFF
--- a/src/AppContainer/index.tsx
+++ b/src/AppContainer/index.tsx
@@ -20,6 +20,15 @@ const AppContainer = () => {
   const { refreshLoggedUser, companiToken, signOut, refreshCompaniToken } = useContext(AuthContext);
 
   const handleUnauthorizedRequest = useCallback(async (error) => {
+    const {
+      companiToken: oldCompaniToken,
+      companiTokenExpireDate: oldCompaniTokenExpireDate,
+    } = await asyncStorage.getCompaniToken();
+    if (asyncStorage.isTokenValid(oldCompaniToken, oldCompaniTokenExpireDate)) {
+      await signOut();
+      return Promise.reject(error);
+    } // handle invalid refreshToken reception from api wich trigger infite 401 calls
+
     await asyncStorage.removeCompaniToken();
     const { refreshToken } = await asyncStorage.getRefreshToken();
     await refreshCompaniToken(refreshToken);

--- a/src/AppContainer/index.tsx
+++ b/src/AppContainer/index.tsx
@@ -50,6 +50,7 @@ const AppContainer = () => {
         response => response,
         async (error) => {
           if (error?.response?.status === 401) await signOut();
+          if ([502, 503].includes(error?.response?.status)) setMaintenanceModalVisible(true);
           return Promise.reject(error);
         }
       );

--- a/src/AppContainer/index.tsx
+++ b/src/AppContainer/index.tsx
@@ -30,7 +30,8 @@ const AppContainer = () => {
   };
 
   const handleAxiosNotLoggedErrorResponse = useCallback(async (error: AxiosError) => {
-    if (error?.response?.status === 502 || error?.response?.status === 503) return handleApiUnavailability(error);
+    const statusCode = error?.response?.status;
+    if (statusCode && [502, 503].includes(statusCode)) return handleApiUnavailability(error);
     return Promise.reject(error);
   }, []);
 
@@ -65,7 +66,7 @@ const AppContainer = () => {
     if (asyncStorage.isTokenValid(storedTokens.companiToken, storedTokens.companiTokenExpireDate)) {
       await signOut();
       return Promise.reject(error);
-    } // handle invalid refreshToken reception from api whsich trigger infinite 401 calls
+    } // handle invalid refreshToken reception from api which trigger infinite 401 calls
 
     await asyncStorage.removeCompaniToken();
     const { refreshToken } = await asyncStorage.getRefreshToken();
@@ -90,8 +91,9 @@ const AppContainer = () => {
   }, [companiToken]);
 
   const handleAxiosLoggedErrorResponse = useCallback(async (error: AxiosError) => {
-    if (error?.response?.status === 401) return handleUnauthorizedRequest(error);
-    if (error?.response?.status === 502 || error?.response?.status === 503) return handleApiUnavailability(error);
+    const statusCode = error?.response?.status;
+    if (statusCode === 401) return handleUnauthorizedRequest(error);
+    if (statusCode && [502, 503].includes(statusCode)) return handleApiUnavailability(error);
     return Promise.reject(error);
   }, [handleUnauthorizedRequest]);
 

--- a/src/AppContainer/index.tsx
+++ b/src/AppContainer/index.tsx
@@ -24,8 +24,8 @@ const AppContainer = () => {
         return response;
       },
       async (error) => {
-        if ([502, 503].includes(error.response.status)) setMaintenanceModalVisible(true);
-        return Promise.reject(error.response);
+        if ([502, 503].includes(error?.response?.status)) setMaintenanceModalVisible(true);
+        return Promise.reject(error);
       }
     );
   };
@@ -49,7 +49,7 @@ const AppContainer = () => {
       .use(
         response => response,
         async (error) => {
-          if (error?.response?.status === 401) return signOut();
+          if (error?.response?.status === 401) await signOut();
           return Promise.reject(error);
         }
       );

--- a/src/AppContainer/index.tsx
+++ b/src/AppContainer/index.tsx
@@ -57,7 +57,7 @@ const AppContainer = () => {
     axiosLoggedRequestInterceptorId.current = axiosLogged.interceptors.request.use(
       async (config: AxiosRequestConfig): Promise<AxiosRequestConfig> => {
         const newConfig = { ...config };
-        newConfig.headers.common['x-access-token'] = companiToken;
+        newConfig.headers['x-access-token'] = companiToken;
         return newConfig;
       },
       err => Promise.reject(err)

--- a/src/api/Authentication.ts
+++ b/src/api/Authentication.ts
@@ -1,3 +1,4 @@
+import axiosLogged from './axios/logged';
 import axiosNotLogged from './axios/notLogged';
 import Environment from '../../environment';
 
@@ -25,5 +26,12 @@ export default {
     const baseURL = await Environment.getBaseUrl({ email });
     const checkToken = await axiosNotLogged.get(`${baseURL}/users/passwordtoken/${token}`, { params: { email } });
     return checkToken.data.data;
+  },
+  updatePassword: async (userId: string, data: object, token = '') => {
+    const baseURL = await Environment.getBaseUrl({ userId });
+    if (!token) await axiosLogged.put(`${baseURL}/users/${userId}/password`, data);
+    else {
+      await axiosNotLogged.put(`${baseURL}/users/${userId}/password`, data, { headers: { 'x-access-token': token } });
+    }
   },
 };

--- a/src/api/Users.ts
+++ b/src/api/Users.ts
@@ -21,13 +21,6 @@ export default {
 
     return user.data.data.user;
   },
-  updatePassword: async (userId: string, data: object, token = '') => {
-    const baseURL = await Environment.getBaseUrl({ userId });
-    if (!token) await axiosLogged.put(`${baseURL}/users/${userId}/password`, data);
-    else {
-      await axiosNotLogged.put(`${baseURL}/users/${userId}/password`, data, { headers: { 'x-access-token': token } });
-    }
-  },
   setUser: async (userId: string | null, data: userInfos) => {
     const baseURL = await Environment.getBaseUrl();
     await axiosLogged.put(`${baseURL}/users/${userId}`, data);

--- a/src/components/modals/MaintenanceModal/index.tsx
+++ b/src/components/modals/MaintenanceModal/index.tsx
@@ -13,7 +13,7 @@ const MaintenanceModal = ({ visible }: MaintenanceModalProps) => (
     <>
       <Text style={modalStyles.title}> L&apos;application est en maintenance !</Text>
       <Text style={[modalStyles.body, styles.body]}>
-        Elle sera à nouveau disponible dans quelques minutes.
+        Elle sera de nouveau disponible dans quelques minutes.
       </Text>
     </>
   </Modal>

--- a/src/context/AuthContext.ts
+++ b/src/context/AuthContext.ts
@@ -74,7 +74,7 @@ const tryLocalSignIn = (dispatch: React.Dispatch<ActionType>) => async () => {
 
 export const { Context, Provider } = createAuthContext(
   authReducer,
-  { signIn, tryLocalSignIn, signOut, refreshLoggedUser },
+  { signIn, tryLocalSignIn, signOut, refreshLoggedUser, refreshCompaniToken },
   {
     companiToken: null,
     appIsReady: false,
@@ -83,5 +83,6 @@ export const { Context, Provider } = createAuthContext(
     tryLocalSignIn: async () => {},
     signOut: async () => {},
     refreshLoggedUser: async () => {},
+    refreshCompaniToken: async () => {},
   }
 );

--- a/src/context/createAuthContext.tsx
+++ b/src/context/createAuthContext.tsx
@@ -11,6 +11,7 @@ export interface StateType {
   signOut: boundFunctionsType,
   tryLocalSignIn: boundFunctionsType,
   refreshLoggedUser: boundFunctionsType,
+  refreshCompaniToken: boundFunctionsType,
 }
 
 export interface ActionType {

--- a/src/screens/Authentication/index.tsx
+++ b/src/screens/Authentication/index.tsx
@@ -26,9 +26,8 @@ const Authentication = ({ navigation }: AuthenticationProps) => {
     try {
       await signIn({ email, password });
     } catch (e) {
-      if (e.status === 401) {
-        setErrorMessage('L\'e-mail et/ou le mot de passe est incorrect');
-      }
+      if (e.response.status === 401) setErrorMessage('L\'e-mail et/ou le mot de passe est incorrect');
+      else setErrorMessage('Impossible de se connecter');
     }
   };
 

--- a/src/screens/PasswordEdition/index.tsx
+++ b/src/screens/PasswordEdition/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PasswordForm from '../../components/PasswordForm';
 import { NavigationType } from '../../types/NavigationType';
-import Users from '../../api/Users';
+import Authentication from '../../api/Authentication';
 
 interface PasswordEditionProps {
   route: { params: { userId: string } },
@@ -14,7 +14,7 @@ const PasswordEdition = ({ route, navigation }: PasswordEditionProps) => {
   const goBack = () => { navigation.navigate('Home', { screen: 'Profile' }); };
 
   const savePassword = async (password: string) => {
-    await Users.updatePassword(userId, { local: { password } });
+    await Authentication.updatePassword(userId, { local: { password } });
     goBack();
   };
 

--- a/src/screens/PasswordReset/index.tsx
+++ b/src/screens/PasswordReset/index.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useCallback } from 'react';
-import Users from '../../api/Users';
+import Authentication from '../../api/Authentication';
 import PasswordForm from '../../components/PasswordForm';
 import { Context as AuthContext } from '../../context/AuthContext';
 import { NavigationType } from '../../types/NavigationType';
@@ -16,7 +16,7 @@ const PasswordReset = ({ route, navigation }: PasswordResetProps) => {
 
   const savePassword = useCallback(async (password: string) => {
     const { userId, email, token } = route.params;
-    await Users.updatePassword(userId, { local: { password } }, token);
+    await Authentication.updatePassword(userId, { local: { password } }, token);
     await signIn({ email, password });
   }, [route.params, signIn]);
 


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- [x] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que je ne touche pas aux routes

- [x] Je n'envoie pas de nouveau paramètre dans une route
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- ~~[ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas~~
- ~~[ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas.~~
- [x] Je n'ai pas changé de constante

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi

Cas d'usage :
Gestion des 401, 502 et 503 :
- **mise en place des intercepteurs 401** :
  - Je passe TOKEN_EXPIRE_TIME à quelques secondes -> J'ai une 401 sur la route que j'essayais d'appeler, puis une 200 sur refreshToken et une 200 sur la route que j'essayais d'appeler. C'est dû au fait que le companiToken a expiré (401) puis qu'on a intercepté cette 401, rafraichi le companiToken en appelant /refreshToken et re-appeler la route avec un companiToken non expiré (`axiosLogged.request(config);`)
  - dans refreshToken de helper > authentication remplacer `const tokenPayload = { _id: new ObjectID() };`. -> je suis déconnecté. C'est pour gérer le cas où le back renvoie un mauvais refreshToken
  - dans Appcontainer -> _if (**!** asyncStorage.isTokenValid(newCompaniToken, companiTokenExpireDate))_ -> je suis déconnecté.
  - toujours dans Appcontainer ->  `await refreshCompaniToken();` (supprimer refreshToken) -> le back renvoie une 401 sur la route refreshToken et je suis déconnecté -> on test le cas où le refreshToken a expiré
- **mise en place des intercepteurs 502 / 503** -> je vois la modale de maintenance lorsque je suis connecté et que le back est down

Commentaires d'Ulysse : 
- _Quand je rentre un mauvais format d’adresse mail à la connexion je n’ai pas le message d’erreur : le Promise.reject de initializeNotLoggedAxios doit renvoyer error et non error.response_ -> done
- _dans le authContext, il faut mettre un catch sur le signin (comme c’est fait côté formation), car tel que c’est fait actuellement les 400 ne sont pas gérées_ -> j'ai géré les 400 mais on n'a pas déplacé cette gestion dans signIn mais directement dans Authentication
- _il faudrait déplacer updatePassword dans authentication pour être cohérent avec l’api_ -> done
- _maintenanceModal : Elle sera à nouveau disponible dans quelques minutes. =>  Elle sera de nouveau disponible dans quelques minutes._ -> done