### PR TITLE
Com 2540 ou COM 2470 fix

### DIFF
--- a/src/components/EventDateTime/index.tsx
+++ b/src/components/EventDateTime/index.tsx
@@ -29,7 +29,7 @@ const EventDateTime = ({
 
   useEffect(() => {
     const formattedDate = new Date(date);
-    setDisplayedDate(`${formattedDate.getDate()} ${capitalizeFirstLetter(MONTHS[formattedDate.getMonth()])}`);
+    setDisplayedDate(`${formattedDate.getDate()} ${capitalizeFirstLetter(MONTHS[formattedDate.getMonth()] || '')}`);
     setDisplayedTime(formatTime(formattedDate));
   }, [date]);
 

--- a/src/components/EventDateTime/index.tsx
+++ b/src/components/EventDateTime/index.tsx
@@ -29,7 +29,7 @@ const EventDateTime = ({
 
   useEffect(() => {
     const formattedDate = new Date(date);
-    setDisplayedDate(`${formattedDate.getDate()} ${capitalizeFirstLetter(MONTHS[formattedDate.getMonth()] || '')}`);
+    setDisplayedDate(`${formattedDate.getDate()} ${capitalizeFirstLetter(MONTHS[formattedDate.getMonth()])}`);
     setDisplayedTime(formatTime(formattedDate));
   }, [date]);
 

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -68,8 +68,7 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
     };
 
     const isSamePayload = state.displayStartPicker === !!action.payload?.start &&
-    state.displayEndPicker === !action.payload?.start &&
-    state.mode === action.payload?.mode;
+      state.displayEndPicker === !action.payload?.start && state.mode === action.payload?.mode;
 
     switch (action.type) {
       case SWITCH_PICKER:
@@ -125,7 +124,7 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
       setErrorMessage('');
 
       if (isBefore(state.endDate, state.startDate)) {
-        setErrorMessage('La date de début est supérieure à la date de fin.');
+        setErrorMessage('La date de début est postérieure à la date de fin.');
         return;
       }
 
@@ -193,8 +192,7 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
         <View style={styles.section}>
           <Text style={styles.sectionText}>Fin</Text>
           <EventDateTime isTimeStamped={event.endDateTimeStamp} onPress={(mode: ModeType) => onPressPicker(false, mode)}
-            date={state.endDate} dateDisabled={dateDisabled}
-            timeDisabled={event.endDateTimeStamp || event.isBilled} />
+            date={state.endDate} dateDisabled={dateDisabled} timeDisabled={event.endDateTimeStamp || event.isBilled} />
           {state.displayEndPicker && <DateTimePicker value={state.endDate} mode={state.mode} is24Hour
             display={isIOS ? 'spinner' : 'default'} onChange={onChangePicker} locale="fr-FR"
             minimumDate={state.mode === TIME ? state.startDate : undefined} />}

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useReducer, useState } from 'react';
-import { View, Text, BackHandler, Platform } from 'react-native';
+import { View, ScrollView, Text, BackHandler, Platform } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { Feather } from '@expo/vector-icons';
 import Events from '../../../api/Events';
@@ -68,6 +68,9 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
 
     switch (action.type) {
       case SWITCH_PICKER:
+        if (state.displayStartPicker === !!action.payload?.start && state.displayEndPicker === !action.payload?.start &&
+          state.mode === action.payload?.mode) return { ...state, displayStartPicker: false, displayEndPicker: false };
+
         return {
           ...state,
           displayStartPicker: !!action.payload?.start,
@@ -153,7 +156,7 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
         {!((event.startDateTimeStamp && event.endDateTimeStamp) || event.isBilled) && <NiPrimaryButton onPress={onSave}
           title='Enregistrer' loading={loading} titleStyle={styles.buttonTitle} style={styles.button} />}
       </View>
-      <View style={styles.container}>
+      <ScrollView style={styles.container}>
         <Text style={styles.name}>
           {`${event.customer?.identity?.firstname} ${event.customer?.identity?.lastname}`}
         </Text>
@@ -186,7 +189,7 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
         <ExitModal onPressConfirmButton={onConfirmExit} onPressCancelButton={() => setExitModal(false)}
           visible={exitModal} contentText={'Supprimer les modifications apportées à cet événement ?'} />
         {!!errorMessage && <NiErrorMessage message={errorMessage} />}
-      </View>
+      </ScrollView>
     </View>
   );
 };

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -174,17 +174,18 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
           <EventDateTime isTimeStamped={event.startDateTimeStamp} date={state.startDate} dateDisabled={dateDisabled}
             onPress={(mode: ModeType) => onPressPicker(true, mode)}
             timeDisabled={event.startDateTimeStamp || event.isBilled} />
-          {state.displayStartPicker && <DateTimePicker value={state.startDate} mode={state.mode} is24Hour locale="fr-FR"
-            maximumDate={(state.mode === TIME && event.endDateTimeStamp) ? state.endDate : undefined} display="default"
-            onChange={onChangePicker} />}
+          {state.displayStartPicker && <DateTimePicker value={state.startDate} mode={state.mode}
+            is24Hour locale="fr-FR" display={isIOS ? 'spinner' : 'default'} onChange={onChangePicker}
+            maximumDate={(state.mode === TIME && event.endDateTimeStamp) ? state.endDate : undefined} />}
         </View>
         <View style={styles.section}>
           <Text style={styles.sectionText}>Fin</Text>
           <EventDateTime isTimeStamped={event.endDateTimeStamp} onPress={(mode: ModeType) => onPressPicker(false, mode)}
-            date={state.endDate} dateDisabled={dateDisabled} timeDisabled={event.endDateTimeStamp || event.isBilled} />
-          {state.displayEndPicker && <DateTimePicker value={state.endDate} mode={state.mode} is24Hour locale="fr-FR"
-            display="default" onChange={onChangePicker} minimumDate={state.mode === TIME ? state.startDate : undefined}
-          />}
+            date={state.endDate} dateDisabled={dateDisabled}
+            timeDisabled={event.endDateTimeStamp || event.isBilled} />
+          {state.displayEndPicker && <DateTimePicker value={state.endDate} mode={state.mode} is24Hour
+            display={isIOS ? 'spinner' : 'default'} onChange={onChangePicker} locale="fr-FR"
+            minimumDate={state.mode === TIME ? state.startDate : undefined} />}
         </View>
         <ExitModal onPressConfirmButton={onConfirmExit} onPressCancelButton={() => setExitModal(false)}
           visible={exitModal} contentText={'Supprimer les modifications apportées à cet événement ?'} />

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -61,10 +61,11 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
   const reducer = (state: StateType, action: ActionType): StateType => {
     const changeEndHourOnStartHourChange = () => {
       if (event.endDateTimeStamp) return state.endDate;
-      if (isBefore(state.endDate, state.startDate)) return state.endDate;
+      if (isBefore(action.payload?.date || state.startDate, state.endDate)) return state.endDate;
 
-      const newDate = addTime(action.payload?.date || state.startDate, dateDiff(state.endDate, state.startDate));
-      return newDate.getDate() !== state.endDate.getDate() ? getEndOfDay(state.endDate) : newDate;
+      const newDate = addTime(action.payload?.date || state.startDate, dateDiff(event.endDate, event.startDate));
+      const newDateIsAfterMidnight = newDate.getDate() !== state.endDate.getDate();
+      return newDateIsAfterMidnight ? getEndOfDay(state.endDate) : newDate;
     };
 
     const isSamePayload = state.displayStartPicker === !!action.payload?.start &&


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

Fix des 3 bugs remontés par ulysse : 
- Sur ios 15 le datetimepicker n'est pas celui qu'on souhaite (spinner)
- sur les petits téléphones (iphone SE 1ère gen par exemple) lorsque le datetimepicker de la date de début est affiché on ne peut pas modifier la date de fin
- sur android on peut mettre une date de fin inférieur à celle de début (impossible à fix car les props minimum / maximumDate ne fonctionnent pas sur android, j'ai donc fait une gestion d'erreur)