### PR TITLE
COM-2526

### DIFF
--- a/src/components/EventAuxiliaryEdition/styles.ts
+++ b/src/components/EventAuxiliaryEdition/styles.ts
@@ -15,7 +15,7 @@ export default StyleSheet.create({
     marginBottom: MARGIN.SM,
     borderWidth: BORDER_WIDTH,
     borderRadius: BORDER_RADIUS.SM,
-    borderColor: COPPER_GREY[200],
+    borderColor: COPPER_GREY[300],
   },
   auxiliaryCellNotEditable: {
     flexDirection: 'row',
@@ -28,7 +28,7 @@ export default StyleSheet.create({
     width: AVATAR_SIZE,
     height: AVATAR_SIZE,
     borderRadius: BORDER_RADIUS.XXL,
-    borderColor: COPPER_GREY[200],
+    borderColor: COPPER_GREY[300],
   },
   auxiliaryInfos: {
     flexDirection: 'row',

--- a/src/components/EventAuxiliaryEditionModal/index.tsx
+++ b/src/components/EventAuxiliaryEditionModal/index.tsx
@@ -6,7 +6,7 @@ import { formatIdentity } from '../../core/helpers/utils';
 import { EventType } from '../../types/EventType';
 import { AuxiliaryType } from '../../types/UserType';
 import { EventEditionActionType } from '../../screens/timeStamping/EventEdition/types';
-import { SET_AUXILIARY } from '../../screens/timeStamping/EventEdition';
+import { SET_FIELD } from '../../screens/timeStamping/EventEdition';
 import styles from './styles';
 
 type EventAuxiliaryEditionModalProps = {
@@ -23,7 +23,7 @@ const EventAuxiliaryEditionModal = ({
   onRequestClose,
 }: EventAuxiliaryEditionModalProps) => {
   const onPress = (aux: EventType['auxiliary']) => {
-    eventEditionDispatch({ type: SET_AUXILIARY, payload: { auxiliary: aux } });
+    eventEditionDispatch({ type: SET_FIELD, payload: { auxiliary: aux } });
     onRequestClose();
   };
 

--- a/src/components/EventDateTime/styles.ts
+++ b/src/components/EventDateTime/styles.ts
@@ -20,7 +20,7 @@ export default StyleSheet.create({
     borderRightWidth: BORDER_WIDTH / 2,
     borderBottomLeftRadius: BORDER_RADIUS.SM,
     borderTopLeftRadius: BORDER_RADIUS.SM,
-    borderColor: COPPER_GREY[200],
+    borderColor: COPPER_GREY[300],
   },
   timeCell: {
     backgroundColor: WHITE,
@@ -33,7 +33,7 @@ export default StyleSheet.create({
     borderLeftWidth: BORDER_WIDTH / 2,
     borderBottomRightRadius: BORDER_RADIUS.SM,
     borderTopRightRadius: BORDER_RADIUS.SM,
-    borderColor: COPPER_GREY[200],
+    borderColor: COPPER_GREY[300],
     flex: 1,
   },
   text: {

--- a/src/components/EventDateTimeEdition/index.tsx
+++ b/src/components/EventDateTimeEdition/index.tsx
@@ -8,7 +8,7 @@ import WarningBanner from '../WarningBanner';
 import NiInput from '../form/Input';
 import ConfirmationModal from '../modals/ConfirmationModal';
 import { EventEditionActionType, EventEditionStateType } from '../../screens/timeStamping/EventEdition/types';
-import { SET_DATES, SET_START, SET_TIME } from '../../screens/timeStamping/EventEdition';
+import { SET_DATES, SET_FIELD, SET_TIME } from '../../screens/timeStamping/EventEdition';
 import { EventHistoryType } from '../../types/EventType';
 import { ModeType } from '../../types/DateTimeType';
 import styles from './styles';
@@ -95,7 +95,7 @@ const EventDateTimeEdition = ({
 
     if ((event.startDateTimeStamp || event.endDateTimeStamp) && mode === DATE) return;
 
-    eventEditionDispatch({ type: SET_START, payload: { start } });
+    eventEditionDispatch({ type: SET_FIELD, payload: { start: start || false } });
     pickerDispatch({ type: SWITCH_PICKER, payload: { startPickerSelected: start, mode } });
   };
 

--- a/src/components/EventFieldEdition/index.tsx
+++ b/src/components/EventFieldEdition/index.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { Text, TouchableOpacity } from 'react-native';
+import NiInput from '../../components/form/Input';
+import styles from './styles';
+
+interface EventFieldEditionProps {
+  buttonTitle: string,
+  buttonIcon: JSX.Element,
+  disabled: boolean,
+  inputTitle: string,
+  text: string,
+  multiline: boolean,
+  onChangeText: (value: string) => void,
+}
+
+const EventFieldEdition = ({
+  buttonTitle,
+  buttonIcon,
+  disabled,
+  inputTitle,
+  text,
+  multiline,
+  onChangeText,
+}: EventFieldEditionProps) => {
+  const [displayText, setDisplayText] = useState<boolean>(!!text);
+
+  return (
+    <>
+      {!displayText && !disabled &&
+      <TouchableOpacity style={styles.textContainer} onPress={() => setDisplayText(true)} >
+        {buttonIcon}
+        <Text style={styles.text}>{buttonTitle}</Text>
+      </TouchableOpacity>}
+      {displayText && <NiInput style={styles.input} caption={inputTitle} value={text} onChangeText={onChangeText}
+        multiline={multiline} disabled={disabled} />}
+    </>
+  );
+};
+
+export default EventFieldEdition;

--- a/src/components/EventFieldEdition/index.tsx
+++ b/src/components/EventFieldEdition/index.tsx
@@ -31,8 +31,11 @@ const EventFieldEdition = ({
           {buttonIcon}
           <Text style={styles.text}>{buttonTitle}</Text>
         </TouchableOpacity>}
-      {displayText && <NiInput caption={inputTitle} value={text} onChangeText={onChangeText}
-        multiline={multiline} disabled={disabled} inputStyleContainer={styles.input} />}
+      {displayText &&
+        <View style={styles.inputContainer}>
+          <NiInput caption={inputTitle} value={text} onChangeText={onChangeText} multiline={multiline}
+            disabled={disabled} />
+        </View>}
     </View>
   );
 };

--- a/src/components/EventFieldEdition/index.tsx
+++ b/src/components/EventFieldEdition/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Text, TouchableOpacity } from 'react-native';
+import { Text, TouchableOpacity, View } from 'react-native';
 import NiInput from '../../components/form/Input';
 import styles from './styles';
 
@@ -25,15 +25,15 @@ const EventFieldEdition = ({
   const [displayText, setDisplayText] = useState<boolean>(!!text);
 
   return (
-    <>
+    <View style={styles.container}>
       {!displayText && !disabled &&
-      <TouchableOpacity style={styles.textContainer} onPress={() => setDisplayText(true)} >
-        {buttonIcon}
-        <Text style={styles.text}>{buttonTitle}</Text>
-      </TouchableOpacity>}
-      {displayText && <NiInput style={styles.input} caption={inputTitle} value={text} onChangeText={onChangeText}
-        multiline={multiline} disabled={disabled} />}
-    </>
+        <TouchableOpacity style={styles.textContainer} onPress={() => setDisplayText(true)}>
+          {buttonIcon}
+          <Text style={styles.text}>{buttonTitle}</Text>
+        </TouchableOpacity>}
+      {displayText && <NiInput caption={inputTitle} value={text} onChangeText={onChangeText}
+        multiline={multiline} disabled={disabled} inputStyleContainer={styles.input} />}
+    </View>
   );
 };
 

--- a/src/components/EventFieldEdition/styles.ts
+++ b/src/components/EventFieldEdition/styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { COPPER, COPPER_GREY } from '../../styles/colors';
+import { COPPER } from '../../styles/colors';
 import { MARGIN, PADDING } from '../../styles/metrics';
 
 export default StyleSheet.create({
@@ -13,11 +13,10 @@ export default StyleSheet.create({
     color: COPPER[600],
     marginHorizontal: MARGIN.SM,
   },
-  input: {
-    borderColor: COPPER_GREY[300],
-    paddingHorizontal: PADDING.SM,
-  },
   container: {
     marginTop: MARGIN.MD,
+  },
+  inputContainer: {
+    marginHorizontal: MARGIN.XXS,
   },
 });

--- a/src/components/EventFieldEdition/styles.ts
+++ b/src/components/EventFieldEdition/styles.ts
@@ -17,4 +17,7 @@ export default StyleSheet.create({
     borderColor: COPPER_GREY[300],
     paddingHorizontal: PADDING.SM,
   },
+  container: {
+    marginTop: MARGIN.MD,
+  },
 });

--- a/src/components/EventFieldEdition/styles.ts
+++ b/src/components/EventFieldEdition/styles.ts
@@ -1,0 +1,20 @@
+import { StyleSheet } from 'react-native';
+import { COPPER, COPPER_GREY } from '../../styles/colors';
+import { MARGIN, PADDING } from '../../styles/metrics';
+
+export default StyleSheet.create({
+  textContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    color: COPPER[600],
+    padding: PADDING.MD,
+  },
+  text: {
+    color: COPPER[600],
+    marginHorizontal: MARGIN.SM,
+  },
+  input: {
+    borderColor: COPPER_GREY[300],
+    paddingHorizontal: PADDING.SM,
+  },
+});

--- a/src/components/form/Input/index.tsx
+++ b/src/components/form/Input/index.tsx
@@ -17,6 +17,7 @@ interface InputProps {
   darkMode?: boolean,
   validationMessage?: string,
   disabled?: boolean,
+  multiline?: boolean,
 }
 
 const Input = ({
@@ -29,6 +30,7 @@ const Input = ({
   darkMode = false,
   validationMessage = '',
   disabled = false,
+  multiline = false,
 }: InputProps) => {
   const [isSelected, setIsSelected] = useState<boolean>(false);
   const [secureTextEntry, setSecureTextEntry] = useState<boolean>(false);
@@ -61,10 +63,10 @@ const Input = ({
         <Text style={textStyle}>{caption}</Text>
       </View>
       <View style={inputStyle.container}>
-        <View style={inputStyle.inputContainer}>
-          <TextInput style={inputStyle.input} onChangeText={onChangeText} onTouchStart={() => setIsSelected(true)}
-            onBlur={() => setIsSelected(false)} secureTextEntry={secureTextEntry} keyboardType={keyboardType}
-            value={value} editable={!disabled} autoCapitalize={autoCapitalize} testID={caption} />
+        <View style={[inputStyle.inputContainer, style]}>
+          <TextInput style={[inputStyle.input, style]} onChangeText={onChangeText} onBlur={() => setIsSelected(false)}
+            onTouchStart={() => setIsSelected(true)} secureTextEntry={secureTextEntry} keyboardType={keyboardType}
+            value={value} editable={!disabled} autoCapitalize={autoCapitalize} testID={caption} multiline={multiline} />
           {type === PASSWORD &&
             <NiFeatherButton name={iconName} style={inputStyle.icon} onPress={onPasswordIconPress} />}
         </View>

--- a/src/components/form/Input/index.tsx
+++ b/src/components/form/Input/index.tsx
@@ -18,7 +18,6 @@ interface InputProps {
   validationMessage?: string,
   disabled?: boolean,
   multiline?: boolean,
-  inputStyleContainer?: Object,
 }
 
 const Input = ({
@@ -32,7 +31,6 @@ const Input = ({
   validationMessage = '',
   disabled = false,
   multiline = false,
-  inputStyleContainer = {},
 }: InputProps) => {
   const [isSelected, setIsSelected] = useState<boolean>(false);
   const [secureTextEntry, setSecureTextEntry] = useState<boolean>(false);
@@ -65,7 +63,7 @@ const Input = ({
         <Text style={textStyle}>{caption}</Text>
       </View>
       <View style={inputStyle.container}>
-        <View style={[inputStyle.inputContainer, inputStyleContainer]}>
+        <View style={inputStyle.inputContainer}>
           <TextInput style={inputStyle.input} onChangeText={onChangeText} onBlur={() => setIsSelected(false)}
             onTouchStart={() => setIsSelected(true)} secureTextEntry={secureTextEntry} keyboardType={keyboardType}
             value={value} editable={!disabled} autoCapitalize={autoCapitalize} testID={caption} multiline={multiline} />

--- a/src/components/form/Input/index.tsx
+++ b/src/components/form/Input/index.tsx
@@ -18,6 +18,7 @@ interface InputProps {
   validationMessage?: string,
   disabled?: boolean,
   multiline?: boolean,
+  inputStyleContainer?: Object,
 }
 
 const Input = ({
@@ -31,6 +32,7 @@ const Input = ({
   validationMessage = '',
   disabled = false,
   multiline = false,
+  inputStyleContainer = {},
 }: InputProps) => {
   const [isSelected, setIsSelected] = useState<boolean>(false);
   const [secureTextEntry, setSecureTextEntry] = useState<boolean>(false);
@@ -63,8 +65,8 @@ const Input = ({
         <Text style={textStyle}>{caption}</Text>
       </View>
       <View style={inputStyle.container}>
-        <View style={[inputStyle.inputContainer, style]}>
-          <TextInput style={[inputStyle.input, style]} onChangeText={onChangeText} onBlur={() => setIsSelected(false)}
+        <View style={[inputStyle.inputContainer, inputStyleContainer]}>
+          <TextInput style={inputStyle.input} onChangeText={onChangeText} onBlur={() => setIsSelected(false)}
             onTouchStart={() => setIsSelected(true)} secureTextEntry={secureTextEntry} keyboardType={keyboardType}
             value={value} editable={!disabled} autoCapitalize={autoCapitalize} testID={caption} multiline={multiline} />
           {type === PASSWORD &&

--- a/src/components/form/Input/styles.ts
+++ b/src/components/form/Input/styles.ts
@@ -25,7 +25,7 @@ const inputStyle = ({ isSelected } : inputStyleProps) => StyleSheet.create({
   inputContainer: {
     width: '100%',
     borderWidth: BORDER_WIDTH,
-    borderColor: isSelected ? COPPER[500] : COPPER_GREY[600],
+    borderColor: isSelected ? COPPER[500] : COPPER_GREY[300],
     alignItems: 'center',
     borderRadius: BORDER_RADIUS.MD,
     display: 'flex',

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -27,8 +27,6 @@ import EventFieldEdition from '../../../components/EventFieldEdition';
 export const SET_HISTORIES = 'setHistories';
 export const SET_DATES = 'setDates';
 export const SET_TIME = 'setTime';
-export const SET_START = 'setStart';
-export const SET_AUXILIARY = 'setAuxiliary';
 export const SET_FIELD = 'setField';
 
 const formatAuxiliary = (auxiliary: UserType) => ({
@@ -100,10 +98,6 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
           }),
           ...(!state.start && { endDate: action.payload?.date || state.endDate }),
         };
-      case SET_START:
-        return { ...state, start: action.payload?.start || false };
-      case SET_AUXILIARY:
-        return { ...state, auxiliary: action.payload?.auxiliary || state.auxiliary };
       case SET_FIELD:
         return { ...state, ...action.payload };
       default:
@@ -143,10 +137,8 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
         return;
       }
 
-      await Events.updateById(
-        event._id,
-        { auxiliary: event.auxiliary._id, ...pick(event, ['startDate', 'endDate', 'misc']) }
-      );
+      const pickedFields = pick(event, ['startDate', 'endDate', 'misc']);
+      await Events.updateById(event._id, { auxiliary: event.auxiliary._id, ...pickedFields });
       navigation.goBack();
     } catch (e) {
       if (e.response.status === 409) setErrorMessage(e.response.data.message);
@@ -224,7 +216,7 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
           <EventFieldEdition text={event.misc} inputTitle="Note" disabled={event.isBilled || false}
             buttonTitle="Ajouter une note" multiline={false}
             buttonIcon={<MaterialIcons name={'playlist-add'} size={24} color={COPPER[600]} />}
-            onChangeText={(value: string) => eventDispatch({ type: SET_FIELD, payload: { misc: value } })} />
+            onChangeText={(value: string) => eventDispatch({ type: SET_FIELD, payload: { misc: value || '' } })} />
         </ScrollView>
       </KeyboardAvoidingView>
     </View>

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -2,8 +2,8 @@ import pick from 'lodash/pick';
 import get from 'lodash.get';
 import isEqual from 'lodash.isequal';
 import React, { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
-import { View, ScrollView, Text, BackHandler } from 'react-native';
-import { Feather } from '@expo/vector-icons';
+import { View, ScrollView, Text, BackHandler, KeyboardAvoidingView } from 'react-native';
+import { Feather, MaterialIcons } from '@expo/vector-icons';
 import EventHistories from '../../../api/EventHistories';
 import Events from '../../../api/Events';
 import Users from '../../../api/Users';
@@ -16,18 +16,20 @@ import EventDateTimeEdition from '../../../components/EventDateTimeEdition';
 import NiPrimaryButton from '../../../components/form/PrimaryButton';
 import EventAuxiliaryEdition from '../../../components/EventAuxiliaryEdition';
 import { COPPER, COPPER_GREY } from '../../../styles/colors';
-import { ICON } from '../../../styles/metrics';
+import { ICON, KEYBOARD_AVOIDING_VIEW_BEHAVIOR, MARGIN } from '../../../styles/metrics';
 import styles from './styles';
 import { EventHistoryType, EventType } from '../../../types/EventType';
 import { UserType, AuxiliaryType } from '../../../types/UserType';
 import { EventEditionActionType, EventEditionProps, EventEditionStateType } from './types';
 import { TIMESTAMPING_ACTION_TYPE_LIST } from '../../../core/data/constants';
+import EventFieldEdition from '../../../components/EventFieldEdition';
 
 export const SET_HISTORIES = 'setHistories';
 export const SET_DATES = 'setDates';
 export const SET_TIME = 'setTime';
 export const SET_START = 'setStart';
 export const SET_AUXILIARY = 'setAuxiliary';
+export const SET_FIELD = 'setField';
 
 const formatAuxiliary = (auxiliary: UserType) => ({
   _id: auxiliary._id,
@@ -102,6 +104,8 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
         return { ...state, start: action.payload?.start || false };
       case SET_AUXILIARY:
         return { ...state, auxiliary: action.payload?.auxiliary || state.auxiliary };
+      case SET_FIELD:
+        return { ...state, ...action.payload };
       default:
         return state;
     }
@@ -110,7 +114,7 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
 
   const onLeave = useCallback(
     () => {
-      const pickFields = ['startDate', 'endDate', 'auxiliary._id'];
+      const pickFields = ['startDate', 'endDate', 'auxiliary._id', 'misc'];
       return isEqual(pick(event, pickFields), pick(initialState, pickFields))
         ? navigation.goBack()
         : setExitModal(true);
@@ -139,7 +143,10 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
         return;
       }
 
-      await Events.updateById(event._id, { auxiliary: event.auxiliary._id, ...pick(event, ['startDate', 'endDate']) });
+      await Events.updateById(
+        event._id,
+        { auxiliary: event.auxiliary._id, ...pick(event, ['startDate', 'endDate', 'misc']) }
+      );
       navigation.goBack();
     } catch (e) {
       if (e.response.status === 409) setErrorMessage(e.response.data.message);
@@ -195,24 +202,31 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
             style={styles.button} />}
       </View>
       {event.isBilled && <Text style={styles.billedHeader}>Intervention facturée</Text> }
-      <ScrollView style={styles.container}>
-        <Text style={styles.name}>{formatIdentity(event.customer.identity, 'FL')}</Text>
-        <View style={styles.addressContainer}>
-          <Feather name="map-pin" size={ICON.SM} color={COPPER_GREY[500]} />
-          <View>
-            <Text style={styles.addressText}>{`${event?.customer?.contact?.primaryAddress?.street}`}</Text>
-            <Text style={styles.addressText}>{formatZipCodeAndCity(event)}</Text>
+      <KeyboardAvoidingView behavior={KEYBOARD_AVOIDING_VIEW_BEHAVIOR} style={styles.keyboardAvoidingView}
+        keyboardVerticalOffset={MARGIN.XL}>
+        <ScrollView style={styles.container}>
+          <Text style={styles.name}>{formatIdentity(event.customer.identity, 'FL')}</Text>
+          <View style={styles.addressContainer}>
+            <Feather name="map-pin" size={ICON.SM} color={COPPER_GREY[500]} />
+            <View>
+              <Text style={styles.addressText}>{`${event?.customer?.contact?.primaryAddress?.street}`}</Text>
+              <Text style={styles.addressText}>{formatZipCodeAndCity(event)}</Text>
+            </View>
           </View>
-        </View>
-        <EventDateTimeEdition event={event} eventEditionDispatch={eventDispatch} refreshHistories={refreshHistories}
-          loading={loading} />
-        <EventAuxiliaryEdition auxiliary={event.auxiliary} auxiliaryOptions={activeAuxiliaries}
-          eventEditionDispatch={eventDispatch} isEditable={isAuxiliaryEditable} />
-        <ConfirmationModal onPressConfirmButton={onConfirmExit} onPressCancelButton={() => setExitModal(false)}
-          visible={exitModal} contentText="Voulez-vous supprimer les modifications apportées à cet événement ?"
-          cancelText="Poursuivre les modifications" confirmText="Supprimer" />
-        {!!errorMessage && <NiErrorMessage message={errorMessage} />}
-      </ScrollView>
+          <EventDateTimeEdition event={event} eventEditionDispatch={eventDispatch} refreshHistories={refreshHistories}
+            loading={loading} />
+          <EventAuxiliaryEdition auxiliary={event.auxiliary} auxiliaryOptions={activeAuxiliaries}
+            eventEditionDispatch={eventDispatch} isEditable={isAuxiliaryEditable} />
+          <ConfirmationModal onPressConfirmButton={onConfirmExit} onPressCancelButton={() => setExitModal(false)}
+            visible={exitModal} contentText="Voulez-vous supprimer les modifications apportées à cet événement ?"
+            cancelText="Poursuivre les modifications" confirmText="Supprimer" />
+          {!!errorMessage && <NiErrorMessage message={errorMessage} />}
+          <EventFieldEdition text={event.misc} inputTitle="Note" disabled={event.isBilled || false}
+            buttonTitle="Ajouter une note" multiline={false}
+            buttonIcon={<MaterialIcons name={'playlist-add'} size={24} color={COPPER[600]} />}
+            onChangeText={(value: string) => eventDispatch({ type: SET_FIELD, payload: { misc: value } })} />
+        </ScrollView>
+      </KeyboardAvoidingView>
     </View>
   );
 };

--- a/src/screens/timeStamping/EventEdition/styles.ts
+++ b/src/screens/timeStamping/EventEdition/styles.ts
@@ -66,4 +66,8 @@ export default StyleSheet.create({
     marginRight: MARGIN.MD,
     color: COPPER_GREY[500],
   },
+  keyboardAvoidingView: {
+    flex: 1,
+    backgroundColor: COPPER_GREY[50],
+  },
 });

--- a/src/screens/timeStamping/EventEdition/styles.ts
+++ b/src/screens/timeStamping/EventEdition/styles.ts
@@ -47,6 +47,9 @@ export default StyleSheet.create({
     textAlign: 'center',
     marginRight: MARGIN.XS,
   },
+  keyboardAvoidingView: {
+    flex: 1,
+  },
   container: {
     flex: 1,
     paddingHorizontal: PADDING.XL,
@@ -65,9 +68,5 @@ export default StyleSheet.create({
     marginLeft: MARGIN.SM,
     marginRight: MARGIN.MD,
     color: COPPER_GREY[500],
-  },
-  keyboardAvoidingView: {
-    flex: 1,
-    backgroundColor: COPPER_GREY[50],
   },
 });

--- a/src/screens/timeStamping/EventEdition/types.ts
+++ b/src/screens/timeStamping/EventEdition/types.ts
@@ -17,5 +17,6 @@ export type EventEditionActionType = {
     start?: boolean,
     histories?: EventType['histories'],
     auxiliary?: EventType['auxiliary'],
+    misc?: string,
   },
 }

--- a/src/types/EventType.ts
+++ b/src/types/EventType.ts
@@ -21,6 +21,7 @@ export type EventType = {
   isBilled?: boolean,
   auxiliary: AuxiliaryType,
   company: string,
+  misc: string,
 };
 
 export type EventHistoryType = {


### PR DESCRIPTION
- [x] J'ai testé sur android
- [x] J'ai testé sur iPhone:

- [ ] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que
  - Non parce que

- [ ] Je n'envoie pas de nouveau paramètre dans une route -np
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- [ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas -np
- [ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas. -np
- [x] Je n'ai pas changé de constante

- J'ai ajouté une variable d'environnement : -np
  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi
  - [ ] J'ai ajouté un message sur le slite pour que la personne qui fait la MEP vérifie que son env.prod est à jour

- Cas d'usage : Depuis la page edition d'intervention, je peux ajouter et editer une note. Si l'intervention est facturée, si il y a une note je ne peux plus l'éditer et si le champ est vide, je ne vois plus le texte cliquable `Ajouter une note`

⚠️ j'ai un soucis d'affichage avec le clavier. Lorsqu'il s'ouvre il cache les champs de la page, il faut scroll pour voir les composants, je n'arrive pas a résoudre ce probleme d'affichage (seulement sur iOS)
Ce probleme est connu: https://github.com/facebook/react-native/issues/16826 , ca vient de la props multiline qui est a true. 
Une des solutions est de passer la props scrollEnabled a false, sauf que ce n'est pas ce qu'on vaut car dans ce cas on ne peut pas scroller dans le champ note s'il est long.
En attendant de résoudre ce bug, je desactive multiline en le passant a false