### PR TITLE
COM-2527 - can add km details

### DIFF
--- a/src/api/Events.ts
+++ b/src/api/Events.ts
@@ -20,7 +20,10 @@ export default {
     const baseURL = await Environment.getBaseUrl();
     await axiosLogged.put(`${baseURL}/events/${id}/timestamping`, data);
   },
-  updateById: async (eventId: string, data: { auxiliary: string, startDate: Date, endDate: Date }) => {
+  updateById: async (
+    eventId: string,
+    data: { auxiliary: string, startDate: Date, endDate: Date, kmDuringEvent: number }
+  ) => {
     const baseURL = await Environment.getBaseUrl();
     await axiosLogged.put(`${baseURL}/events/${eventId}`, data);
   },

--- a/src/api/Events.ts
+++ b/src/api/Events.ts
@@ -3,6 +3,7 @@ import Environment from '../../environment';
 import { EventTypeEnum } from '../types/EventType';
 
 export type timeStampEventPayloadType = { action: string, reason?: string, startDate?: Date, endDate?: Date };
+type updateEventsPayloadType = { auxiliary: string, startDate: Date, endDate: Date, kmDuringEvent: number };
 
 export default {
   list: async (params: {
@@ -20,11 +21,8 @@ export default {
     const baseURL = await Environment.getBaseUrl();
     await axiosLogged.put(`${baseURL}/events/${id}/timestamping`, data);
   },
-  updateById: async (
-    eventId: string,
-    data: { auxiliary: string, startDate: Date, endDate: Date, kmDuringEvent: number }
-  ) => {
+  updateById: async (eventId: string, payload: updateEventsPayloadType) => {
     const baseURL = await Environment.getBaseUrl();
-    await axiosLogged.put(`${baseURL}/events/${eventId}`, data);
+    await axiosLogged.put(`${baseURL}/events/${eventId}`, payload);
   },
 };

--- a/src/components/EventFieldEdition/index.tsx
+++ b/src/components/EventFieldEdition/index.tsx
@@ -9,8 +9,10 @@ interface EventFieldEditionProps {
   disabled: boolean,
   inputTitle: string,
   text: string,
-  multiline: boolean,
   onChangeText: (value: string) => void,
+  multiline?: boolean,
+  suffix?: string,
+  type?: string,
 }
 
 const EventFieldEdition = ({
@@ -19,8 +21,10 @@ const EventFieldEdition = ({
   disabled,
   inputTitle,
   text,
-  multiline,
   onChangeText,
+  multiline = false,
+  suffix = '',
+  type = '',
 }: EventFieldEditionProps) => {
   const [displayText, setDisplayText] = useState<boolean>(!!text);
 
@@ -34,7 +38,7 @@ const EventFieldEdition = ({
       {displayText &&
         <View style={styles.inputContainer}>
           <NiInput caption={inputTitle} value={text} onChangeText={onChangeText} multiline={multiline}
-            disabled={disabled} />
+            disabled={disabled} suffix={suffix} type={type} />
         </View>}
     </View>
   );

--- a/src/components/form/Input/index.tsx
+++ b/src/components/form/Input/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, TextInput, KeyboardTypeOptions } from 'react-native';
 import styles, { InputStyleType } from './styles';
 import NiFeatherButton from '../../FeatherButton';
-import { PASSWORD, EMAIL } from '../../../core/data/constants';
+import { PASSWORD, EMAIL, NUMBER } from '../../../core/data/constants';
 import { WHITE } from '../../../styles/colors';
 import Shadow from '../../design/Shadow';
 import { FeatherType } from '../../../types/IconType';
@@ -18,6 +18,7 @@ interface InputProps {
   validationMessage?: string,
   disabled?: boolean,
   multiline?: boolean,
+  suffix?: string,
 }
 
 const Input = ({
@@ -31,6 +32,7 @@ const Input = ({
   validationMessage = '',
   disabled = false,
   multiline = false,
+  suffix = '',
 }: InputProps) => {
   const [isSelected, setIsSelected] = useState<boolean>(false);
   const [secureTextEntry, setSecureTextEntry] = useState<boolean>(false);
@@ -42,8 +44,11 @@ const Input = ({
 
   useEffect(() => {
     setAutoCapitalize(['password', 'email'].includes(type) ? 'none' : 'sentences');
-    setKeyboardType(type === EMAIL ? 'email-address' : 'default');
     setSecureTextEntry(type === PASSWORD);
+
+    if (type === EMAIL) setKeyboardType('email-address');
+    else if (type === NUMBER) setKeyboardType('decimal-pad');
+    else setKeyboardType('default');
   }, [type]);
 
   useEffect(() => setIconName(secureTextEntry ? 'eye-off' : 'eye'), [secureTextEntry]);
@@ -69,6 +74,7 @@ const Input = ({
             value={value} editable={!disabled} autoCapitalize={autoCapitalize} testID={caption} multiline={multiline} />
           {type === PASSWORD &&
             <NiFeatherButton name={iconName} style={inputStyle.icon} onPress={onPasswordIconPress} />}
+          {!!suffix && <Text style={styles({ isSelected }).suffix}>{suffix}</Text>}
         </View>
         {isSelected && <Shadow />}
       </View>

--- a/src/components/form/Input/styles.ts
+++ b/src/components/form/Input/styles.ts
@@ -15,6 +15,7 @@ export interface InputStyleType {
   captionContainer: object,
   caption: object,
   invalid: object,
+  suffix: object,
 }
 
 const inputStyle = ({ isSelected } : inputStyleProps) => StyleSheet.create({
@@ -55,6 +56,10 @@ const inputStyle = ({ isSelected } : inputStyleProps) => StyleSheet.create({
     ...FIRA_SANS_ITALIC.SM,
     color: ORANGE[600],
     marginTop: MARGIN.XXS,
+  },
+  suffix: {
+    paddingHorizontal: PADDING.LG,
+    color: COPPER_GREY[500],
   },
 });
 

--- a/src/core/data/constants.ts
+++ b/src/core/data/constants.ts
@@ -12,6 +12,7 @@ export const PASSWORD = 'password';
 export const EMAIL = 'email';
 export const PHONE = 'phone';
 export const MOBILE = 'mobile';
+export const NUMBER = 'number';
 
 // REGEX
 export const EMAIL_REGEX = /^\s*[\w.+]+@([\w-]+\.)+[\w-]{2,4}\s*$/;

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -109,7 +109,8 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
 
   const onLeave = useCallback(
     () => {
-      const pickFields = ['startDate', 'endDate', 'auxiliary._id', 'misc', 'kmDuringEvent'];
+      const pickFields = ['startDate', 'endDate', 'auxiliary._id', 'misc'];
+      if (event.kmDuringEvent) pickFields.push('kmDuringEvent');
       return isEqual(pick(event, pickFields), pick(initialState, pickFields))
         ? navigation.goBack()
         : setExitModal(true);
@@ -201,7 +202,7 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
         <FeatherButton style={styles.arrow} name="arrow-left" onPress={onLeave} color={COPPER[400]}
           size={ICON.SM} />
         <Text style={styles.text}>{formatDate(event.startDate, true)}</Text>
-        {!((event.startDateTimeStamp && event.endDateTimeStamp) || event.isBilled) &&
+        {!event.isBilled &&
           <NiPrimaryButton onPress={onSave} title="Enregistrer" loading={loading} titleStyle={styles.buttonTitle}
             style={styles.button} />}
       </View>

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -225,15 +225,14 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
             visible={exitModal} contentText="Voulez-vous supprimer les modifications apportées à cet événement ?"
             cancelText="Poursuivre les modifications" confirmText="Supprimer" />
           {!!errorMessage && <NiErrorMessage message={errorMessage} />}
-          <EventFieldEdition text={event.misc} inputTitle="Note" disabled={event.isBilled || false}
-            buttonTitle="Ajouter une note" multiline={false}
+          <EventFieldEdition text={event.misc} inputTitle="Note" disabled={!!event.isBilled}
+            buttonTitle="Ajouter une note"
             buttonIcon={<MaterialIcons name={'playlist-add'} size={24} color={COPPER[600]} />}
             onChangeText={(value: string) => eventDispatch({ type: SET_FIELD, payload: { misc: value || '' } })} />
-          <EventFieldEdition text={event.kmDuringEvent ? event.kmDuringEvent.toString() : ''}
-            disabled={event.isBilled || false} inputTitle={'Déplacement véhiculé avec le/la bénéficiaire'} suffix={'km'}
-            buttonTitle="Ajouter un déplacement véhiculé avec le/la bénéficiaire" type={NUMBER}
-            buttonIcon={<MaterialCommunityIcons name='truck-outline' size={24} color={COPPER[600]} />}
-            onChangeText={onChangeKmDuringEvent} />
+          <EventFieldEdition text={event.kmDuringEvent ? event.kmDuringEvent.toString() : ''} suffix={'km'}
+            disabled={!!event.isBilled} inputTitle={'Déplacement véhiculé avec le/la bénéficiaire'} type={NUMBER}
+            buttonTitle="Ajouter un déplacement véhiculé avec le/la bénéficiaire" onChangeText={onChangeKmDuringEvent}
+            buttonIcon={<MaterialCommunityIcons name='truck-outline' size={24} color={COPPER[600]} />} />
         </ScrollView>
       </KeyboardAvoidingView>
     </View>

--- a/src/screens/timeStamping/EventEdition/styles.ts
+++ b/src/screens/timeStamping/EventEdition/styles.ts
@@ -53,6 +53,7 @@ export default StyleSheet.create({
   container: {
     flex: 1,
     paddingHorizontal: PADDING.XL,
+    marginBottom: MARGIN.LG,
   },
   name: {
     ...FIRA_SANS_BLACK.XL,

--- a/src/screens/timeStamping/EventEdition/types.ts
+++ b/src/screens/timeStamping/EventEdition/types.ts
@@ -20,5 +20,6 @@ export type EventEditionActionType = {
     histories?: EventType['histories'],
     auxiliary?: EventType['auxiliary'],
     misc?: string,
+    kmDuringEvent?: string,
   },
 }

--- a/src/types/EventType.ts
+++ b/src/types/EventType.ts
@@ -22,6 +22,7 @@ export type EventType = {
   auxiliary: AuxiliaryType,
   company: string,
   misc: string,
+  kmDuringEvent: string,
 };
 
 export type EventHistoryType = {


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- [x] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que
  - Non parce que

- [x] Je n'envoie pas de nouveau paramètre dans une route
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- [ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas -np
- [ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas. -np
- [x] Je n'ai pas changé de constante

- J'ai ajouté une variable d'environnement : -np
  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi
  - [ ] J'ai ajouté un message sur le slite pour que la personne qui fait la MEP vérifie que son env.prod est à jour

- Cas d'usage : ETQ auxiliaire, sur la page edition d'une intervention, je peux ajouter un déplacement véhiculé effectué avec le beneficiaire. 
  - Si aucun déplacement enregistré: le bouton cliquable `Ajouter un déplacement véhiculé avec le/la beneficiaire`
  - Si un déplacement a deja été enregistré pour cette intervention l'input indiquant le nombre de km parcourus apparait 
  - Si l'intervention est facturée, on ne peut plus editer le nombre de km (si le nbre de km vaut 0, le bouton cliquable n'apparait pas)
