### PR TITLE
COM-2597 - add validation before saving changes

### DIFF
--- a/src/components/ErrorMessage/styles.ts
+++ b/src/components/ErrorMessage/styles.ts
@@ -1,13 +1,13 @@
 import { StyleSheet } from 'react-native';
 import { MARGIN } from '../../styles/metrics';
 import { ORANGE, RED } from '../../styles/colors';
-import { FIRA_SANS_REGULAR } from '../../styles/fonts';
+import { FIRA_SANS_ITALIC } from '../../styles/fonts';
 import { WARNING } from '../../core/data/constants';
 
 export default (type: string) => StyleSheet.create({
   message: {
-    ...FIRA_SANS_REGULAR.SM,
-    color: type === WARNING ? ORANGE[500] : RED,
+    ...FIRA_SANS_ITALIC.SM,
+    color: type === WARNING ? ORANGE[600] : RED,
     marginBottom: MARGIN.MD,
   },
 });

--- a/src/components/EventDateTimeEdition/index.tsx
+++ b/src/components/EventDateTimeEdition/index.tsx
@@ -2,10 +2,11 @@ import React, { useReducer, useState, useEffect } from 'react';
 import { View, Text } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import EventHistories from '../../api/EventHistories';
-import { DATE, isIOS, TIME, TIMESTAMPING_ACTION_TYPE_LIST } from '../../core/data/constants';
+import { DATE, isIOS, TIME, TIMESTAMPING_ACTION_TYPE_LIST, WARNING } from '../../core/data/constants';
 import EventDateTime from '../EventDateTime';
 import WarningBanner from '../WarningBanner';
 import NiInput from '../form/Input';
+import NiErrorMessage from '../ErrorMessage';
 import ConfirmationModal from '../modals/ConfirmationModal';
 import { EventEditionActionType, EventEditionStateType } from '../../screens/timeStamping/EventEdition/types';
 import { SET_DATES, SET_FIELD, SET_TIME } from '../../screens/timeStamping/EventEdition';
@@ -18,6 +19,7 @@ interface EventDateTimeEditionProps {
   eventEditionDispatch: (action: EventEditionActionType) => void,
   refreshHistories: () => void,
   loading: boolean,
+  dateErrorMessage?: string,
 }
 
 interface StateType {
@@ -70,6 +72,7 @@ const EventDateTimeEdition = ({
   eventEditionDispatch,
   refreshHistories,
   loading,
+  dateErrorMessage = '',
 }: EventDateTimeEditionProps) => {
   const [picker, pickerDispatch] = useReducer(reducer, initialState);
   const [maximumStartDate, setMaximumStartDate] = useState<Date | undefined>(undefined);
@@ -179,6 +182,7 @@ const EventDateTimeEdition = ({
           disabled={event.isBilled} onPress={(mode: ModeType) => onPressPicker(false, mode)} />
         {picker.displayEndPicker && <DateTimePicker value={event.endDate} mode={picker.mode} is24Hour locale="fr-FR"
           display={isIOS ? 'spinner' : 'default'} onChange={onChangePicker} minimumDate={minimumEndDate} />}
+        <NiErrorMessage message={dateErrorMessage} type={WARNING} />
       </View>
       <ConfirmationModal visible={confirmationModal} title="Cet évènement a déjà été horodaté" exitButton
         cancelText="Retour" confirmText="Annuler l'horodatage" onPressConfirmButton={openCancellationModal}

--- a/src/components/EventFieldEdition/index.tsx
+++ b/src/components/EventFieldEdition/index.tsx
@@ -13,6 +13,7 @@ interface EventFieldEditionProps {
   multiline?: boolean,
   suffix?: string,
   type?: string,
+  errorMessage?: string,
 }
 
 const EventFieldEdition = ({
@@ -25,6 +26,7 @@ const EventFieldEdition = ({
   multiline = false,
   suffix = '',
   type = '',
+  errorMessage = '',
 }: EventFieldEditionProps) => {
   const [displayText, setDisplayText] = useState<boolean>(!!text);
 
@@ -38,7 +40,7 @@ const EventFieldEdition = ({
       {displayText &&
         <View style={styles.inputContainer}>
           <NiInput caption={inputTitle} value={text} onChangeText={onChangeText} multiline={multiline}
-            disabled={disabled} suffix={suffix} type={type} />
+            disabled={disabled} suffix={suffix} type={type} validationMessage={errorMessage} />
         </View>}
     </View>
   );

--- a/src/core/data/constants.ts
+++ b/src/core/data/constants.ts
@@ -17,7 +17,7 @@ export const NUMBER = 'number';
 // REGEX
 export const EMAIL_REGEX = /^\s*[\w.+]+@([\w-]+\.)+[\w-]{2,4}\s*$/;
 export const PHONE_REGEX = /^\s*(?:(?:\+|00)33|0)\s*[1-9](?:[\s.-]*\d{2}){4}(?:[\s]*)$/;
-export const FLOAT_REGEX = /^([0-9]+([.][0-9]*)?|[.][0-9]+)$/;
+export const FLOAT_REGEX = /^([0-9]+([.][0-9]+)?|[.][0-9]+)$/;
 
 // DATE
 export const ONE_YEAR_IN_MILLISECONDS = 31536000000;

--- a/src/core/data/constants.ts
+++ b/src/core/data/constants.ts
@@ -17,6 +17,7 @@ export const NUMBER = 'number';
 // REGEX
 export const EMAIL_REGEX = /^\s*[\w.+]+@([\w-]+\.)+[\w-]{2,4}\s*$/;
 export const PHONE_REGEX = /^\s*(?:(?:\+|00)33|0)\s*[1-9](?:[\s.-]*\d{2}){4}(?:[\s]*)$/;
+export const FLOAT_REGEX = /^([0-9]+([.][0-9]*)?|[.][0-9]+)$/;
 
 // DATE
 export const ONE_YEAR_IN_MILLISECONDS = 31536000000;

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -139,9 +139,9 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
         return;
       }
 
-      const isValidNumber = event.kmDuringEvent.match(FLOAT_REGEX);
+      const isValidNumber = event.kmDuringEvent ? event.kmDuringEvent.toString().match(FLOAT_REGEX) : true;
       if (!isValidNumber) {
-        setErrorMessage('Champ invalide : veuillez saisir un nombre.');
+        setErrorMessage('Champ invalide : veuillez saisir un nombre positif.');
         return;
       }
 
@@ -239,7 +239,7 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
             disabled={!!event.isBilled} inputTitle={'Déplacement véhiculé avec le/la bénéficiaire'} type={NUMBER}
             buttonTitle="Ajouter un déplacement véhiculé avec le/la bénéficiaire" onChangeText={onChangeKmDuringEvent}
             buttonIcon={<MaterialCommunityIcons name='truck-outline' size={24} color={COPPER[600]} />} />
-          {!!errorMessage && <NiErrorMessage message={errorMessage} />}
+          <NiErrorMessage message={errorMessage} />
         </ScrollView>
       </KeyboardAvoidingView>
     </View>

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -70,7 +70,10 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
   const [kmDuringEventErrorMessage, setKmDuringEventErrorMessage] = useState<string>('');
   const [isValidationAttempted, setIsValidationAttempted] = useState<boolean>(false);
   const [isValid, setIsValid] = useState<boolean>(true);
-  const [invalid, setInvalid] = useState<EditedEventValidType>({ dateRange: false, kmDuringEvent: false });
+  const [editedEventValidations, setEditedEventValidations] = useState<EditedEventValidType>({
+    dateRange: false,
+    kmDuringEvent: false,
+  });
 
   const reducer = (state: EventEditionStateType, action: EventEditionActionType): EventEditionStateType => {
     const changeEndHourOnStartHourChange = () => {
@@ -167,27 +170,27 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
   };
 
   useEffect(() => {
-    setInvalid({
+    setEditedEventValidations({
       dateRange: isBefore(editedEvent.endDate, editedEvent.startDate),
       kmDuringEvent: !!editedEvent.kmDuringEvent && !editedEvent.kmDuringEvent.toString().match(FLOAT_REGEX),
     });
   }, [editedEvent]);
 
   useEffect(() => {
-    const { dateRange, kmDuringEvent } = invalid;
+    const { dateRange, kmDuringEvent } = editedEventValidations;
     if (dateRange || kmDuringEvent) setIsValid(false);
     else setIsValid(true);
-  }, [invalid]);
+  }, [editedEventValidations]);
 
   useEffect(() => {
-    if (invalid.dateRange && isValidationAttempted) {
+    if (editedEventValidations.dateRange && isValidationAttempted) {
       setDateErrorMessage('Champ invalide: la date de début doit être antérieure à la date de fin.');
     } else setDateErrorMessage('');
 
-    if (invalid.kmDuringEvent && isValidationAttempted) {
+    if (editedEventValidations.kmDuringEvent && isValidationAttempted) {
       setKmDuringEventErrorMessage('Champ invalide : veuillez saisir un nombre positif.');
     } else setKmDuringEventErrorMessage('');
-  }, [invalid, isValidationAttempted]);
+  }, [editedEventValidations, isValidationAttempted]);
 
   const onConfirmExit = () => {
     setExitModal(false);

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -21,7 +21,7 @@ import styles from './styles';
 import { EventHistoryType, EventType } from '../../../types/EventType';
 import { UserType } from '../../../types/UserType';
 import { EventEditionActionType, EventEditionProps, EventEditionStateType, FormattedAuxiliaryType } from './types';
-import { NUMBER, TIMESTAMPING_ACTION_TYPE_LIST } from '../../../core/data/constants';
+import { FLOAT_REGEX, NUMBER, TIMESTAMPING_ACTION_TYPE_LIST } from '../../../core/data/constants';
 import EventFieldEdition from '../../../components/EventFieldEdition';
 
 export const SET_HISTORIES = 'setHistories';
@@ -139,6 +139,12 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
         return;
       }
 
+      const isValidNumber = event.kmDuringEvent.match(FLOAT_REGEX);
+      if (!isValidNumber) {
+        setErrorMessage('Champ invalide : veuillez saisir un nombre.');
+        return;
+      }
+
       const pickedFields = pick(event, ['startDate', 'endDate', 'misc']);
       await Events.updateById(
         event._id,
@@ -225,7 +231,6 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
           <ConfirmationModal onPressConfirmButton={onConfirmExit} onPressCancelButton={() => setExitModal(false)}
             visible={exitModal} contentText="Voulez-vous supprimer les modifications apportées à cet événement ?"
             cancelText="Poursuivre les modifications" confirmText="Supprimer" />
-          {!!errorMessage && <NiErrorMessage message={errorMessage} />}
           <EventFieldEdition text={event.misc} inputTitle="Note" disabled={!!event.isBilled}
             buttonTitle="Ajouter une note"
             buttonIcon={<MaterialIcons name={'playlist-add'} size={24} color={COPPER[600]} />}
@@ -234,6 +239,7 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
             disabled={!!event.isBilled} inputTitle={'Déplacement véhiculé avec le/la bénéficiaire'} type={NUMBER}
             buttonTitle="Ajouter un déplacement véhiculé avec le/la bénéficiaire" onChangeText={onChangeKmDuringEvent}
             buttonIcon={<MaterialCommunityIcons name='truck-outline' size={24} color={COPPER[600]} />} />
+          {!!errorMessage && <NiErrorMessage message={errorMessage} />}
         </ScrollView>
       </KeyboardAvoidingView>
     </View>

--- a/src/screens/timeStamping/EventEdition/types.ts
+++ b/src/screens/timeStamping/EventEdition/types.ts
@@ -23,3 +23,5 @@ export type EventEditionActionType = {
     kmDuringEvent?: string,
   },
 }
+
+export type EditedEventValidType = { dateRange: boolean, kmDuringEvent: boolean };


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- [x] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que
  - Non parce que

- [x] Je n'envoie pas de nouveau paramètre dans une route
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- [ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas -np
- [ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas. -np
- [x] Je n'ai pas changé de constante

- J'ai ajouté une variable d'environnement : -np 
  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi
  - [ ] J'ai ajouté un message sur le slite pour que la personne qui fait la MEP vérifie que son env.prod est à jour

- Cas d'usage :
- Ajout d'une validation sur le kmDuringEvent: lorsque l'utilisateur entre un nombre invalide ou des lettres --> erreur au moment de l'enregistrement.

Pour tester: Sur la page d'édition d'un evenement, dans le champ `Déplacement vehiculé avec le/la beneficiaire`: 
- saisir un nombre invalide --> erreur lors de l'enregistrement
- si le clavier est numérique, retirer type={NUMBER} pour pouvoir saisir des lettres --> erreur lors de l'enregistrement
