### PR TITLE
COM-2527 - change kmDuringEvent input title

### DIFF
--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -269,8 +269,8 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
             onChangeText={(value: string) => editedEventDispatch({ type: SET_FIELD, payload: { misc: value || '' } })}
             buttonIcon={<MaterialIcons name={'playlist-add'} size={24} color={COPPER[600]} />} />
           <EventFieldEdition text={editedEvent.kmDuringEvent ? editedEvent.kmDuringEvent.toString() : ''} suffix={'km'}
-            disabled={!!editedEvent.isBilled} inputTitle={'Déplacement véhiculé avec le/la bénéficiaire'} type={NUMBER}
-            buttonTitle="Ajouter un déplacement véhiculé avec le/la bénéficiaire" onChangeText={onChangeKmDuringEvent}
+            disabled={!!editedEvent.isBilled} inputTitle={'Déplacement véhiculé avec bénéficiaire'} type={NUMBER}
+            buttonTitle="Ajouter un déplacement véhiculé avec bénéficiaire" onChangeText={onChangeKmDuringEvent}
             buttonIcon={<MaterialCommunityIcons name='truck-outline' size={24} color={COPPER[600]} />}
             errorMessage={kmDuringEventErrorMessage || ''} />
           <ErrorMessage message={apiErrorMessage || ''}/>


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [ ] J'ai testé sur android

- [ ] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que
  - Non parce que migration mongoose --> erreur `options usecreateindex, usefindandmodify are not supported`

- [x] Je n'envoie pas de nouveau paramètre dans une route
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- [x] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas
- [x] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas.
- [x] Je n'ai pas changé de constante

- J'ai ajouté une variable d'environnement : -np
  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi
  - [ ] J'ai ajouté un message sur le slite pour que la personne qui fait la MEP vérifie que son env.prod est à jour

- Cas d'usage : Modification du titre de l'input `Déplacement véhiculé avec bénéficiaire`
