### PR TITLE
Com 2647

### DIFF
--- a/src/components/Switch/styles.ts
+++ b/src/components/Switch/styles.ts
@@ -18,8 +18,9 @@ const switchStyle = ({ backgroundColor } : SwitchStyleProps) => StyleSheet.creat
   textContainer: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingHorizontal: PADDING.LG,
-    justifyContent: 'space-around',
+    paddingLeft: '19%',
+    paddingRight: '22%',
+    justifyContent: 'space-between',
     height: '100%',
   },
   text: {

--- a/src/components/Switch/styles.ts
+++ b/src/components/Switch/styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { BORDER_RADIUS, PADDING, MARGIN, BUTTON_HEIGHT } from '../../styles/metrics';
+import { BORDER_RADIUS, PADDING, MARGIN, BUTTON_HEIGHT, SWITCH_TEXT_WIDTH } from '../../styles/metrics';
 import { WHITE } from '../../styles/colors';
 import { FIRA_SANS_MEDIUM } from '../../styles/fonts';
 
@@ -18,13 +18,13 @@ const switchStyle = ({ backgroundColor } : SwitchStyleProps) => StyleSheet.creat
   textContainer: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingLeft: '19%',
-    paddingRight: '22%',
-    justifyContent: 'space-between',
+    justifyContent: 'space-around',
     height: '100%',
   },
   text: {
     ...FIRA_SANS_MEDIUM.MD,
+    width: SWITCH_TEXT_WIDTH,
+    textAlign: 'center',
   },
   toggle: {
     backgroundColor: WHITE,

--- a/src/styles/metrics.ts
+++ b/src/styles/metrics.ts
@@ -68,6 +68,7 @@ export const TAB_BAR_HEIGHT = 72;
 export const HEADER_HEIGHT = 64;
 export const BUTTON_INTERVENTION_WIDTH = 128;
 export const TAB_BAR_LABEL_WIDTH = 110;
+export const SWITCH_TEXT_WIDTH = 64;
 
 export const SCREEN_HEIGHT = width < height ? height : width;
 export const SMALL_SCREEN_MAX_HEIGHT = 568;


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- [] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que
  - Non parce que

- [x] Je n'envoie pas de nouveau paramètre dans une route
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- [ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas -np
- [ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas. -np
- [x] Je n'ai pas changé de constante

- J'ai ajouté une variable d'environnement : -np
  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi
  - [ ] J'ai ajouté un message sur le slite pour que la personne qui fait la MEP vérifie que son env.prod est à jour

- Retour de Romain: le “début” n’est pas centré j’ai l’impression. Quand le toggle est en mode “début”, on voit qu’il est légèrement sur la droite

Cela vient du fait qu'on utilisait la propriete `space-around` et que les textes `Début` et `Fin` n'ont pas le meme longueurs. Le texte de `Fin` était bien centré mais pas le texte `Début`.
