### PR TITLE
COM-2610 -fix shadow display on Android

### DIFF
--- a/src/components/EventFieldEdition/index.tsx
+++ b/src/components/EventFieldEdition/index.tsx
@@ -38,10 +38,8 @@ const EventFieldEdition = ({
           <Text style={styles.text}>{buttonTitle}</Text>
         </TouchableOpacity>}
       {displayText &&
-        <View style={styles.inputContainer}>
-          <NiInput caption={inputTitle} value={text} onChangeText={onChangeText} multiline={multiline}
-            disabled={disabled} suffix={suffix} type={type} validationMessage={errorMessage} />
-        </View>}
+        <NiInput caption={inputTitle} value={text} onChangeText={onChangeText} multiline={multiline}
+          disabled={disabled} suffix={suffix} type={type} validationMessage={errorMessage} />}
     </View>
   );
 };

--- a/src/components/EventFieldEdition/styles.ts
+++ b/src/components/EventFieldEdition/styles.ts
@@ -17,6 +17,6 @@ export default StyleSheet.create({
     marginTop: MARGIN.MD,
   },
   inputContainer: {
-    marginHorizontal: MARGIN.XXS,
+    marginHorizontal: MARGIN.XS,
   },
 });

--- a/src/components/EventFieldEdition/styles.ts
+++ b/src/components/EventFieldEdition/styles.ts
@@ -16,7 +16,4 @@ export default StyleSheet.create({
   container: {
     marginTop: MARGIN.MD,
   },
-  inputContainer: {
-    marginHorizontal: MARGIN.XS,
-  },
 });

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -244,7 +244,7 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
       <NiHeader onPressIcon={onLeave} title={headerTitle} loading={loading} onPressButton={onSave} />
       {editedEvent.isBilled && <Text style={styles.billedHeader}>Intervention facturée</Text> }
       <KeyboardAwareScrollView extraScrollHeight={KEYBOARD_PADDING_TOP} enableOnAndroid>
-        <ScrollView style={styles.container}>
+        <ScrollView contentContainerStyle={styles.container}>
           <Text style={styles.name}>{formatIdentity(editedEvent.customer.identity, 'FL')}</Text>
           <TouchableOpacity style={styles.customerProfileButton} disabled={loading}
             onPress={() => goToCustomerProfile(editedEvent.customer._id)}>


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- [x] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que
  - Non parce que

- [x] Je n'envoie pas de nouveau paramètre dans une route
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- [ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas -np
- [ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas. -np
- [x] Je n'ai pas changé de constante

- J'ai ajouté une variable d'environnement : -np
  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi
  - [ ] J'ai ajouté un message sur le slite pour que la personne qui fait la MEP vérifie que son env.prod est à jour

- Cas d'usage : Retour de Romain: sur Android, lorsque l'input est selectionné les ombres sur les cotés sont rongées par la marge de l'écran. 
<img width="290" alt="Capture d’écran 2022-02-04 à 10 53 13" src="https://user-images.githubusercontent.com/81675019/152508716-7255cf4b-3ae1-4916-adc5-4809d697e061.png">

- J'ai rectifié pour les input de la fiche beneficiaire dans le ticket COM-2611.
- Dans ce ticket je fais la modification sur les inputs de la page `EventEdition`

Romain propose de retravailler le style de l'input pour qu'il devienne dynamique. (cf [son commentaire](https://compani.atlassian.net/browse/COM-2610?focusedCommentId=12621&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-12621) )

Ca demande de faire pas mal de modifs, que pensez-vous de creer un ticket pour ca? 
