### PR TITLE
COM-2660-2 - fix Romain's reviews

### DIFF
--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -179,6 +179,7 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
       else setApiErrorMessage('Une erreur s\'est produite, si le problème persiste, contactez le support technique.');
     } finally {
       setLoading(false);
+      navigation.goBack();
     }
   };
 


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] Mes changements entrainent une incompatibilité avec l'ancienne version de l'api
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles :

#### Retours de Romain : 
- Finalement, le comportement de “enregistrer” gagne à être différent selon la page sur laquelle on est
      - sur une page “intervention” : on se rend sur cette page en général parce qu’on veut éditer quelque chose. Une fois la modif faite, on veut revenir sur l’endroit où on était avant => le bouton “enregistrer” doit enregistrer puis revenir en arrière
     - sur une page “bénéficiaire” : on se rend sur cette page pour consulter de l’information. Il se peut que je décide de faire une modif, mais je suis avant tout là pour consulter => le bouton “enregistrer” doit enregistrer puis rester sur la page

- Design input de type texte (comme par exemple le champ “note”) : viser le même design que le champ “transport pour aller à l’intervention”

Pour ce dernier point, le soucis est qu'il y a un paddingTop de 5 en trop sur l'input lorsque le champ multiline vaut true, on peut le supprimer en passant `paddingTop: 0` mais je ne suis pas fan de cette solution rapide, je préfère creer un ticket a part pour creuser un peu plus et vraiment retravailler le style de l'input. J'ai donc cree un ticket sur product board: `[REFACTO] - Retravailler le design de l'input Note`

- Comment tester ? :
   - sur la page beneficiaire, si je modifie des infos et enregistre, je reste sur cette page
   - sur la page edition d'intervention, si je modifie des infos et enregistre --> je suis redirigé vers la page précédente

_Si tu as lu cette description, pense a réagir avec un :eye:_
