### PR TITLE
COM-2693 - fix bug when customer hasn't referent auxiliary

### DIFF
--- a/src/screens/CustomerProfile/index.tsx
+++ b/src/screens/CustomerProfile/index.tsx
@@ -67,12 +67,10 @@ const CustomerProfile = ({ route }: CustomerProfileProp) => {
     try {
       setLoading(true);
       const currentCustomer = await Customers.getById(customerId);
-      if (currentCustomer.identity) {
-        setInitialCustomer({
-          ...currentCustomer,
-          referent: currentCustomer.referent ? formatAuxiliary(currentCustomer.referent) : {},
-        });
-      }
+      setInitialCustomer({
+        ...currentCustomer,
+        referent: currentCustomer.referent ? formatAuxiliary(currentCustomer.referent) : {},
+      });
     } catch (e) {
       console.error(e);
     } finally {

--- a/src/screens/CustomerProfile/index.tsx
+++ b/src/screens/CustomerProfile/index.tsx
@@ -67,7 +67,12 @@ const CustomerProfile = ({ route }: CustomerProfileProp) => {
     try {
       setLoading(true);
       const currentCustomer = await Customers.getById(customerId);
-      setInitialCustomer({ ...currentCustomer, referent: formatAuxiliary(currentCustomer.referent) });
+      if (currentCustomer.identity) {
+        setInitialCustomer({
+          ...currentCustomer,
+          referent: currentCustomer.referent ? formatAuxiliary(currentCustomer.referent) : {},
+        });
+      }
     } catch (e) {
       console.error(e);
     } finally {
@@ -184,8 +189,7 @@ const CustomerProfile = ({ route }: CustomerProfileProp) => {
               <Text style={styles.sectionText}>Référents</Text>
               <NiPersonSelect title={'Auxiliaire référent(e)'} placeHolder={'Pas d\'auxiliaire référent(e)'}
                 person={formatAuxiliary(editedCustomer.referent || customer.referent)}
-                personOptions={activeAuxiliaries} style={styles.referent}
-                onSelectPerson={onSelectAuxiliary} />
+                personOptions={activeAuxiliaries} style={styles.referent} onSelectPerson={onSelectAuxiliary} />
               {!!editedCustomer?.referent?.contact?.phone &&
                 <View style={styles.infoItem}>
                   <MaterialIcons name="phone" size={ICON.SM} color={COPPER[500]} />


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning: -np

- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] Mes changements entrainent une incompatibilité avec l'ancienne version de l'api
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : auxiliaire

- Cas d'usage : Depuis la fiche beneficiaire, je peux editer l'auxiliaire référent 

- Comment tester ? :
   - depuis la webApp, mettre `Pas d'auxiliaire référent` pour un beneficiaire
   - sur mobile, aller sur la fiche de ce beneficiaire
   - sélectionner un auxiliaire référent
   - enregistrer
   - verifier que le changement a bien été fait 

_Si tu as lu cette description, pense a réagir avec un :eye:_
