### PR TITLE
Com 2728

### DIFF
--- a/src/api/InternalHours.ts
+++ b/src/api/InternalHours.ts
@@ -5,7 +5,6 @@ import { InternalHoursType } from '../types/EventType';
 export default {
   list: async (): Promise<InternalHoursType[]> => {
     const baseURL = await Environment.getBaseUrl();
-
     const internalHours = await axiosLogged.get(`${baseURL}/internalhours`);
     return internalHours.data.data.internalHours;
   },

--- a/src/api/InternalHours.ts
+++ b/src/api/InternalHours.ts
@@ -1,0 +1,12 @@
+import axiosLogged from './axios/logged';
+import Environment from '../../environment';
+import { InternalHoursType } from '../types/EventType';
+
+export default {
+  list: async (): Promise<InternalHoursType[]> => {
+    const baseURL = await Environment.getBaseUrl();
+
+    const internalHours = await axiosLogged.get(`${baseURL}/internalhours`);
+    return internalHours.data.data.internalHours;
+  },
+};

--- a/src/components/EventCell/index.tsx
+++ b/src/components/EventCell/index.tsx
@@ -130,7 +130,7 @@ const EventCell = ({ event }: TimeStampingProps) => {
               <Text style={style.eventInfo}> - {CompaniDate(eventInfos.endDate).format('HH:mm')}</Text>}
             {eventInfos.endDateTimeStamp && <Feather name="check" color={COPPER[500]} size={ICON.SM} />}
           </View>
-          <Text style={style.eventInfo}>{eventInfos.customer.address.toLocaleLowerCase()}</Text>
+          <Text style={style.eventInfo}>{eventInfos.address.toLocaleLowerCase()}</Text>
         </View>
         {!eventInfos.endDateTimeStamp && eventInfos.type === INTERVENTION &&
         <TouchableOpacity hitSlop={hitSlop}

--- a/src/components/EventCell/index.tsx
+++ b/src/components/EventCell/index.tsx
@@ -133,10 +133,10 @@ const EventCell = ({ event }: TimeStampingProps) => {
           <Text style={style.eventInfo}>{eventInfos.address.toLocaleLowerCase()}</Text>
         </View>
         {!eventInfos.endDateTimeStamp && eventInfos.type === INTERVENTION &&
-        <TouchableOpacity hitSlop={hitSlop}
-          onPress={() => (eventInfos?.startDateTimeStamp ? requestPermission(false) : requestPermission(true)) }>
-          <MaterialIcons name="qr-code-2" size={ICON.LG} color={COPPER[500]} />
-        </TouchableOpacity>}
+          <TouchableOpacity hitSlop={hitSlop}
+            onPress={() => (eventInfos?.startDateTimeStamp ? requestPermission(false) : requestPermission(true)) }>
+            <MaterialIcons name="qr-code-2" size={ICON.LG} color={COPPER[500]} />
+          </TouchableOpacity>}
       </TouchableOpacity>
       <CameraAccessModal visible={modalVisible} onRequestClose={() => setModalVisible(false)}
         onPressAskAgain={askPermissionAgain} goToManualTimeStamping={goToManualTimeStamping} />

--- a/src/components/EventCell/index.tsx
+++ b/src/components/EventCell/index.tsx
@@ -82,6 +82,7 @@ const EventCell = ({ event }: TimeStampingProps) => {
         ...event,
         startDateTimeStamp: eventInfos.startDateTimeStamp,
         endDateTimeStamp: eventInfos.endDateTimeStamp,
+        title: cellInfos.title,
       },
     }
   );
@@ -117,10 +118,9 @@ const EventCell = ({ event }: TimeStampingProps) => {
   };
 
   return (
-    <View>
-      <TouchableOpacity style={style.cell} onPress={goToEventEdition}
-        disabled={eventInfos.type !== INTERVENTION}>
-        <View style={style.infoContainer}>
+    <View style={style.cell}>
+      <TouchableOpacity style={style.infoContainer} onPress={goToEventEdition}>
+        <View>
           <Text style={style.eventTitle}>{cellInfos.title}</Text>
           <View style={style.timeContainer}>
             {!!eventInfos.startDate &&

--- a/src/components/EventCell/reducers/events.ts
+++ b/src/components/EventCell/reducers/events.ts
@@ -5,8 +5,8 @@ type EventStateType = {
     civility: string,
     lastname: string,
     firstname: string,
-    address: string,
   },
+  address: string,
   startDate: string | null,
   endDate: string | null,
   startDateTimeStamp: boolean,
@@ -25,8 +25,8 @@ const initialState = {
     civility: '',
     lastname: '',
     firstname: '',
-    address: '',
   },
+  address: '',
   startDate: null,
   endDate: null,
   startDateTimeStamp: false,
@@ -46,10 +46,10 @@ const eventReducer = (state: EventStateType, action: EventActionType): EventStat
           civility: action.payload.event?.customer?.identity?.title || '',
           lastname: action.payload.event?.customer?.identity?.lastname || '',
           firstname: action.payload.event?.customer?.identity?.firstname || '',
-          address: action.payload.event?.customer?.contact?.primaryAddress?.street ||
-            action.payload.event?.address?.street ||
-            '',
         },
+        address: action.payload.event?.customer?.contact?.primaryAddress?.street ||
+          action.payload.event?.address?.street ||
+          '',
         startDate: action.payload.event?.startDate || null,
         endDate: action.payload.event?.endDate || null,
         type: action.payload.event?.type || '',

--- a/src/components/EventCell/styles.ts
+++ b/src/components/EventCell/styles.ts
@@ -20,9 +20,7 @@ export type eventCellStyleType = {
 
 const eventCellStyle = ({ borderColor, backgroundColor }: eventCellType) => StyleSheet.create({
   cell: {
-    flexDirection: 'row',
     flex: 1,
-    justifyContent: 'space-between',
     borderRadius: BORDER_RADIUS.MD,
     borderWidth: BORDER_WIDTH,
     borderLeftWidth: LEFT_BORDER_CELL,
@@ -34,6 +32,9 @@ const eventCellStyle = ({ borderColor, backgroundColor }: eventCellType) => Styl
   },
   infoContainer: {
     flex: 1,
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
   },
   eventTitle: {
     ...FIRA_SANS_BOLD.MD,

--- a/src/components/EventDateTimeEdition/index.tsx
+++ b/src/components/EventDateTimeEdition/index.tsx
@@ -21,6 +21,7 @@ interface EventDateTimeEditionProps {
   refreshHistories: () => void,
   loading: boolean,
   dateErrorMessage?: string,
+  style?: object,
 }
 
 interface StateType {
@@ -74,6 +75,7 @@ const EventDateTimeEdition = ({
   refreshHistories,
   loading,
   dateErrorMessage = '',
+  style = {},
 }: EventDateTimeEditionProps) => {
   const [picker, pickerDispatch] = useReducer(reducer, initialState);
   const [maximumStartDate, setMaximumStartDate] = useState<string | undefined>(undefined);
@@ -171,7 +173,7 @@ const EventDateTimeEdition = ({
   };
 
   return (
-    <>
+    <View style={style}>
       <View style={styles.section}>
         <Text style={styles.sectionText}>Début</Text>
         <EventDateTime isTimeStamped={event.startDateTimeStamp} date={event.startDate} loading={loading}
@@ -202,7 +204,7 @@ const EventDateTimeEdition = ({
         <NiInput caption="Motif" value={reason} onChangeText={setReason} validationMessage={errorMessage}
           validationStyle={styles.errorMessage} />
       </ConfirmationModal>
-    </>
+    </View>
   );
 };
 

--- a/src/components/EventDateTimeEdition/index.tsx
+++ b/src/components/EventDateTimeEdition/index.tsx
@@ -180,7 +180,7 @@ const EventDateTimeEdition = ({
           is24Hour locale="fr-FR" display={isIOS ? 'spinner' : 'default'} onChange={onChangePicker}
           maximumDate={maximumStartDate ? CompaniDate(maximumStartDate).toDate() : undefined} />}
       </View>
-      <View style={styles.section}>
+      <View>
         <Text style={styles.sectionText}>Fin</Text>
         <EventDateTime isTimeStamped={event.endDateTimeStamp} date={event.endDate} loading={loading}
           disabled={event.isBilled} onPress={(mode: ModeType) => onPressPicker(false, mode)} />

--- a/src/components/EventFieldEdition/styles.ts
+++ b/src/components/EventFieldEdition/styles.ts
@@ -14,6 +14,6 @@ export default StyleSheet.create({
     marginHorizontal: MARGIN.SM,
   },
   container: {
-    marginTop: MARGIN.MD,
+    marginTop: MARGIN.LG,
   },
 });

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -30,8 +30,9 @@ import { ICON, KEYBOARD_PADDING_TOP } from '../../../styles/metrics';
 import styles from './styles';
 import { EventHistoryType } from '../../../types/EventType';
 import { UserType, FormattedUserType } from '../../../types/UserType';
-import { EditedEventValidType, EventEditionActionType, EventEditionProps, EventEditionStateType } from './types';
+import { EditedEventValidType, EventEditionActionType, EventEditionStateType, EventEditionType } from './types';
 import InternalHours from '../../../api/InternalHours';
+import { NavigationType } from '../../../types/NavigationType';
 
 export const SET_HISTORIES = 'setHistories';
 export const SET_DATES = 'setDates';
@@ -58,6 +59,11 @@ const isTimeStampHistory = (eh: EventHistoryType) =>
   TIMESTAMPING_ACTION_TYPE_LIST.includes(eh.action) && !eh.isCancelled;
 
 const isEditable = (ev: EventEditionStateType) => !ev.startDateTimeStamp && !ev.endDateTimeStamp && !ev.isBilled;
+
+interface EventEditionProps {
+  route: { params: { event: EventEditionType } },
+  navigation: NavigationType,
+}
 
 const EventEdition = ({ route, navigation }: EventEditionProps) => {
   const { event } = route.params;
@@ -297,15 +303,16 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
               <Text style={styles.customerProfileButtonTitle}>Fiche bénéficiaire</Text>
               <Feather name="chevron-right" color={COPPER[500]}/>
             </TouchableOpacity>}
-          <View style={styles.addressContainer}>
+          {editedEvent.address && <View style={styles.addressContainer}>
             <Feather name="map-pin" size={ICON.SM} color={COPPER_GREY[500]} />
             <View>
               <Text style={styles.addressText}>{formatAddress(editedEvent)}</Text>
               <Text style={styles.addressText}>{formatZipCodeAndCity(editedEvent)}</Text>
             </View>
-          </View>
+          </View>}
           <EventDateTimeEdition event={editedEvent} eventEditionDispatch={editedEventDispatch}
-            refreshHistories={refreshHistories} loading={loading} dateErrorMessage={dateErrorMessage || ''}/>
+            refreshHistories={refreshHistories} loading={loading} dateErrorMessage={dateErrorMessage || ''}
+            style={styles.date} />
           {editedEvent.type === INTERVENTION &&
           <>
             <NiPersonSelect title={'Intervenant'} person={editedEvent.auxiliary}

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -50,7 +50,9 @@ const formatZipCodeAndCity = (event: EventEditionStateType) => {
   return `${zipCode} ${city}`;
 };
 
-const formatAddress = (event: EventEditionStateType) => get(event, 'address.street') || '';
+const formatAddress = (event: EventEditionStateType) => (
+  get(event, 'customer.contact.primaryAddress.street') || get(event, 'address.street') || ''
+);
 
 const isTimeStampHistory = (eh: EventHistoryType) =>
   TIMESTAMPING_ACTION_TYPE_LIST.includes(eh.action) && !eh.isCancelled;
@@ -88,7 +90,7 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
 
   const reducer = (state: EventEditionStateType, action: EventEditionActionType): EventEditionStateType => {
     const changeEndHourOnStartHourChange = () => {
-      if (route.params.event.endDateTimeStamp) return state.endDate;
+      if (event.endDateTimeStamp) return state.endDate;
 
       const updatedStartDate = CompaniDate(action.payload?.date || state.startDate);
       if (updatedStartDate.isBefore(state.endDate)) return state.endDate;

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -257,7 +257,7 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
       {editedEvent.isBilled && <Text style={styles.billedHeader}>Intervention facturée</Text> }
       <KeyboardAwareScrollView extraScrollHeight={KEYBOARD_PADDING_TOP} enableOnAndroid>
         <ScrollView contentContainerStyle={styles.container}>
-          <Text style={styles.name}>{formatIdentity(editedEvent.customer.identity, 'FL')}</Text>
+          <Text style={styles.name}>{editedEvent.title}</Text>
           <TouchableOpacity style={styles.customerProfileButton} disabled={loading}
             onPress={() => goToCustomerProfile(editedEvent.customer._id)}>
             <Text style={styles.customerProfileButtonTitle}>Fiche bénéficiaire</Text>

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -85,7 +85,6 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
     dateRange: false,
     kmDuringEvent: false,
   });
-  const [isIntervention, setIsIntervention] = useState<boolean>(false);
   const [internalHourOptions, setInternalHourOptions] = useState<InternalHourOptionsType[]>([]);
 
   const reducer = (state: EventEditionStateType, action: EventEditionActionType): EventEditionStateType => {
@@ -265,8 +264,6 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
     });
   };
 
-  useEffect(() => { if (editedEvent.type === INTERVENTION) setIsIntervention(true); }, [editedEvent.type]);
-
   const getInternalHours = useCallback(async () => {
     try {
       const internalHours = await InternalHours.list();
@@ -294,11 +291,12 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
       <KeyboardAwareScrollView extraScrollHeight={KEYBOARD_PADDING_TOP} enableOnAndroid style={styles.screen}>
         <ScrollView contentContainerStyle={styles.container}>
           <Text style={styles.name}>{editedEvent.title}</Text>
-          {isIntervention && <TouchableOpacity style={styles.customerProfileButton} disabled={loading}
-            onPress={() => goToCustomerProfile(editedEvent.customer._id)}>
-            <Text style={styles.customerProfileButtonTitle}>Fiche bénéficiaire</Text>
-            <Feather name="chevron-right" color={COPPER[500]}/>
-          </TouchableOpacity>}
+          {editedEvent.type === INTERVENTION &&
+            <TouchableOpacity style={styles.customerProfileButton} disabled={loading}
+              onPress={() => goToCustomerProfile(editedEvent.customer._id)}>
+              <Text style={styles.customerProfileButtonTitle}>Fiche bénéficiaire</Text>
+              <Feather name="chevron-right" color={COPPER[500]}/>
+            </TouchableOpacity>}
           <View style={styles.addressContainer}>
             <Feather name="map-pin" size={ICON.SM} color={COPPER_GREY[500]} />
             <View>
@@ -308,7 +306,7 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
           </View>
           <EventDateTimeEdition event={editedEvent} eventEditionDispatch={editedEventDispatch}
             refreshHistories={refreshHistories} loading={loading} dateErrorMessage={dateErrorMessage || ''}/>
-          {isIntervention &&
+          {editedEvent.type === INTERVENTION &&
           <>
             <NiPersonSelect title={'Intervenant'} person={editedEvent.auxiliary}
               personOptions={activeAuxiliaries} onSelectPerson={onSelectPerson} isEditable={isAuxiliaryEditable}

--- a/src/screens/timeStamping/EventEdition/styles.ts
+++ b/src/screens/timeStamping/EventEdition/styles.ts
@@ -4,10 +4,12 @@ import { FIRA_SANS_BLACK, FIRA_SANS_REGULAR } from '../../../styles/fonts';
 import { MARGIN, PADDING } from '../../../styles/metrics';
 
 export default StyleSheet.create({
+  screen: {
+    backgroundColor: COPPER_GREY[50],
+  },
   container: {
     flex: 1,
     paddingHorizontal: PADDING.XL,
-    backgroundColor: COPPER_GREY[50],
   },
   billedHeader: {
     ...FIRA_SANS_REGULAR.MD,

--- a/src/screens/timeStamping/EventEdition/styles.ts
+++ b/src/screens/timeStamping/EventEdition/styles.ts
@@ -18,6 +18,9 @@ export default StyleSheet.create({
     textAlign: 'center',
     paddingVertical: PADDING.MD,
   },
+  date: {
+    marginTop: MARGIN.XL,
+  },
   customerProfileButton: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -36,7 +39,7 @@ export default StyleSheet.create({
   addressContainer: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginVertical: MARGIN.XL,
+    marginTop: MARGIN.XL,
   },
   addressText: {
     marginLeft: MARGIN.SM,

--- a/src/screens/timeStamping/EventEdition/styles.ts
+++ b/src/screens/timeStamping/EventEdition/styles.ts
@@ -22,7 +22,6 @@ export default StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     marginTop: MARGIN.XS,
-    marginBottom: MARGIN.XL,
   },
   customerProfileButtonTitle: {
     ...FIRA_SANS_REGULAR.MD,
@@ -37,7 +36,7 @@ export default StyleSheet.create({
   addressContainer: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginBottom: MARGIN.XL,
+    marginVertical: MARGIN.XL,
   },
   addressText: {
     marginLeft: MARGIN.SM,

--- a/src/screens/timeStamping/EventEdition/types.ts
+++ b/src/screens/timeStamping/EventEdition/types.ts
@@ -1,11 +1,7 @@
 import { ModeType } from '../../../types/DateTimeType';
 import { EventType } from '../../../types/EventType';
-import { NavigationType } from '../../../types/NavigationType';
 
-export type EventEditionProps = {
-  route: { params: { event: EventType } },
-  navigation: NavigationType,
-};
+export type EventEditionType = EventType & { title: string };
 
 export type EventEditionStateType = {
   _id: EventType['_id'],

--- a/src/screens/timeStamping/EventEdition/types.ts
+++ b/src/screens/timeStamping/EventEdition/types.ts
@@ -7,7 +7,11 @@ export interface EventEditionProps {
   navigation: NavigationType,
 }
 
-export type EventEditionStateType = EventType & { start: boolean, histories: EventType['histories'] };
+export type EventEditionStateType = EventType & {
+  start: boolean,
+  histories: EventType['histories'],
+  internalHour: string
+};
 
 export type EventEditionActionType = {
   type: string,
@@ -20,6 +24,7 @@ export type EventEditionActionType = {
     misc?: string,
     kmDuringEvent?: string,
     transportMode?: string,
+    internalHour?: string,
   },
 }
 

--- a/src/screens/timeStamping/EventEdition/types.ts
+++ b/src/screens/timeStamping/EventEdition/types.ts
@@ -2,15 +2,30 @@ import { ModeType } from '../../../types/DateTimeType';
 import { EventType } from '../../../types/EventType';
 import { NavigationType } from '../../../types/NavigationType';
 
-export interface EventEditionProps {
+export type EventEditionProps = {
   route: { params: { event: EventType } },
   navigation: NavigationType,
-}
+};
 
-export type EventEditionStateType = EventType & {
-  start: boolean,
+export type EventEditionStateType = {
+  _id: EventType['_id'],
+  customer: EventType['customer'],
+  startDate: EventType['startDate'],
+  endDate: EventType['endDate'],
+  startDateTimeStamp?: EventType['startDateTimeStamp'],
+  endDateTimeStamp?: EventType['endDateTimeStamp'],
+  isBilled?: EventType['isBilled'],
+  auxiliary: EventType['auxiliary'],
+  company: EventType['company'],
+  misc: EventType['misc'],
+  kmDuringEvent: EventType['kmDuringEvent'],
+  transportMode: EventType['transportMode'],
+  type: EventType['type'],
   histories: EventType['histories'],
-  internalHour: string
+  address: { street: string },
+  title: string,
+  start: boolean,
+  internalHour: string,
 };
 
 export type EventEditionActionType = {
@@ -25,6 +40,7 @@ export type EventEditionActionType = {
     kmDuringEvent?: string,
     transportMode?: string,
     internalHour?: string,
+    title?: string,
   },
 }
 

--- a/src/types/EventType.ts
+++ b/src/types/EventType.ts
@@ -25,7 +25,7 @@ export type EventType = {
   kmDuringEvent: string,
   transportMode: string,
   type: EventTypeEnum,
-  internalHour: { name: string },
+  internalHour: { _id: string, name: string },
   address: { street: string },
   title: string,
 };
@@ -35,4 +35,12 @@ export type EventHistoryType = {
   action: string,
   update: { startHour?: Date, endHour?: Date },
   isCancelled: boolean,
+};
+
+export type InternalHoursType = {
+  _id: string,
+  name: string,
+  company: string,
+  createdAt: string,
+  updatedAt: string,
 };

--- a/src/types/EventType.ts
+++ b/src/types/EventType.ts
@@ -27,7 +27,6 @@ export type EventType = {
   type: EventTypeEnum,
   internalHour: { _id: string, name: string },
   address: { street: string },
-  title: string,
 };
 
 export type EventHistoryType = {

--- a/src/types/EventType.ts
+++ b/src/types/EventType.ts
@@ -27,6 +27,7 @@ export type EventType = {
   type: EventTypeEnum,
   internalHour: { name: string },
   address: { street: string },
+  title: string,
 };
 
 export type EventHistoryType = {


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning: -np

- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] Mes changements entrainent une incompatibilité avec l'ancienne version de l'api
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : Auxiliaire

- Cas d'usage : je peux accéder a la page edition d'une intervention en cliquant sur une heure interne 

- Comment tester ? : 
- cliquer sur la cellule d'une heure interne
   - verifier que les informations `Type de l'heure interne`, `adresse`, `Date/heure` s'affichent 
   - editer le type d'heure interne
   - editer le champ note
   - retourner sur la page précédente sans enregistrer -> la modale de confirmation s'ouvre
   - enregistrer les modifs --> l'evenement est bien modifié
- verifier que sur la page d'édition d'une information, le nom/prenom et adresse  du beneficiaire apparaissent


**Rmq**: Le reducer prend beaucoup de place. Que pensez-vous de creer des tickets tech pour mettre en place la bonne pratique dont Sophie a parlé hier en Daily:  creer un dossier a part pour sortir le reducer du composant et alléger le composant
-> K: Je suis d'accord


_Si tu as lu cette description, pense a réagir avec un :eye:_
