### PR TITLE
COM-2741 - Fix on large screen

### DIFF
--- a/src/components/EventCell/index.tsx
+++ b/src/components/EventCell/index.tsx
@@ -117,10 +117,10 @@ const EventCell = ({ event }: TimeStampingProps) => {
   };
 
   return (
-    <View style={style.cell}>
-      <TouchableOpacity style={style.infoContainer} onPress={goToEventEdition}
+    <View>
+      <TouchableOpacity style={style.cell} onPress={goToEventEdition}
         disabled={eventInfos.type !== INTERVENTION}>
-        <View>
+        <View style={style.infoContainer}>
           <Text style={style.eventTitle}>{cellInfos.title}</Text>
           <View style={style.timeContainer}>
             {!!eventInfos.startDate &&
@@ -133,7 +133,7 @@ const EventCell = ({ event }: TimeStampingProps) => {
           <Text style={style.eventInfo}>{eventInfos.customer.address.toLocaleLowerCase()}</Text>
         </View>
         {!eventInfos.endDateTimeStamp && eventInfos.type === INTERVENTION &&
-        <TouchableOpacity hitSlop={hitSlop} style={style.iconContainer}
+        <TouchableOpacity hitSlop={hitSlop}
           onPress={() => (eventInfos?.startDateTimeStamp ? requestPermission(false) : requestPermission(true)) }>
           <MaterialIcons name="qr-code-2" size={ICON.LG} color={COPPER[500]} />
         </TouchableOpacity>}

--- a/src/components/EventCell/styles.ts
+++ b/src/components/EventCell/styles.ts
@@ -16,13 +16,13 @@ export type eventCellStyleType = {
   eventTitle: object,
   eventInfo: object,
   timeContainer: object,
-  iconContainer: object,
 };
 
-const eventCellStyle = ({ borderColor, backgroundColor } : eventCellType) => StyleSheet.create({
+const eventCellStyle = ({ borderColor, backgroundColor }: eventCellType) => StyleSheet.create({
   cell: {
-    display: 'flex',
     flexDirection: 'row',
+    flex: 1,
+    justifyContent: 'space-between',
     borderRadius: BORDER_RADIUS.MD,
     borderWidth: BORDER_WIDTH,
     borderLeftWidth: LEFT_BORDER_CELL,
@@ -30,12 +30,9 @@ const eventCellStyle = ({ borderColor, backgroundColor } : eventCellType) => Sty
     backgroundColor,
     marginHorizontal: MARGIN.MD,
     paddingHorizontal: PADDING.LG,
+    paddingVertical: PADDING.LG,
   },
   infoContainer: {
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    paddingVertical: PADDING.LG,
     flex: 1,
   },
   eventTitle: {
@@ -52,9 +49,6 @@ const eventCellStyle = ({ borderColor, backgroundColor } : eventCellType) => Sty
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
-  },
-  iconContainer: {
-    justifyContent: 'flex-start',
   },
 });
 

--- a/src/screens/timeStamping/QRCodeScanner/styles.ts
+++ b/src/screens/timeStamping/QRCodeScanner/styles.ts
@@ -18,7 +18,7 @@ export default StyleSheet.create({
     position: 'relative',
   },
   limits: {
-    width: IS_LARGE_SCREEN ? 250 : '50%',
+    width: IS_LARGE_SCREEN ? '70%' : '50%',
     aspectRatio: 1,
   },
   error: {


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone - Iphone SE - 8s - 11 Pro - 8
- [x] J'ai testé sur android - Nexus 4, Huawei de Corentin, Android Large, Google Pixel 2

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] Mes changements entrainent une incompatibilité avec l'ancienne version de l'api
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : auxiliaire

- Cas d'usage : 
Correction de deux bugs : 
  - Sur l'Agenda, lorsque mon bénéficiaire à un nom long, l'icône pour horodater pouvait sortir de la cellule
  - Sur le scanner, sur les grands écrans, on pouvait encore avoir le bug où on ne voyait plus le bouton d'horotage manuel. Le soucis avait été corrigé sur les petits écran mais pas les grands

- Comment tester ? :
Tester la correction des 2 bugs sur le maximum d'appareil possible

_Si tu as lu cette description, pense a réagir avec un :eye:_
