### PR TITLE
COM-2739-2 shorten size of 'check' icon

### DIFF
--- a/src/components/EventCell/index.tsx
+++ b/src/components/EventCell/index.tsx
@@ -130,7 +130,7 @@ const EventCell = ({ event }: TimeStampingProps) => {
             {!!eventInfos.endDate &&
               <Text style={style.eventInfo}> - {CompaniDate(eventInfos.endDate).format('HH:mm')}</Text>}
             {eventInfos.endDateTimeStamp &&
-              <MaterialCommunityIcons name="check-bold" color={COPPER[500]}size={ICON.XXS} />}
+              <MaterialCommunityIcons name="check-bold" color={COPPER[500]} size={ICON.XXS} />}
           </View>
           <Text style={style.eventInfo}>{eventInfos.address.toLocaleLowerCase()}</Text>
         </View>

--- a/src/components/EventCell/index.tsx
+++ b/src/components/EventCell/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useReducer, useState } from 'react';
 import { View, Text, Alert, TouchableOpacity } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { Camera } from 'expo-camera';
-import { Feather, MaterialIcons } from '@expo/vector-icons';
+import { MaterialIcons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { TIMESTAMPING_ACTION_TYPE_LIST, GRANTED, INTERVENTION } from '../../core/data/constants';
 import CompaniDate from '../../core/helpers/dates/companiDates';
 import { EventType, EventHistoryType } from '../../types/EventType';
@@ -125,10 +125,12 @@ const EventCell = ({ event }: TimeStampingProps) => {
           <View style={style.timeContainer}>
             {!!eventInfos.startDate &&
               <Text style={style.eventInfo}>{CompaniDate(eventInfos.startDate).format('HH:mm')}</Text>}
-            {eventInfos.startDateTimeStamp && <Feather name="check" color={COPPER[500]} size={ICON.XS}/>}
+            {eventInfos.startDateTimeStamp &&
+              <MaterialCommunityIcons name="check-bold" color={COPPER[500]} size={ICON.XXS}/>}
             {!!eventInfos.endDate &&
               <Text style={style.eventInfo}> - {CompaniDate(eventInfos.endDate).format('HH:mm')}</Text>}
-            {eventInfos.endDateTimeStamp && <Feather name="check" color={COPPER[500]} size={ICON.XS} />}
+            {eventInfos.endDateTimeStamp &&
+              <MaterialCommunityIcons name="check-bold" color={COPPER[500]}size={ICON.XXS} />}
           </View>
           <Text style={style.eventInfo}>{eventInfos.address.toLocaleLowerCase()}</Text>
         </View>

--- a/src/components/EventCell/styles.ts
+++ b/src/components/EventCell/styles.ts
@@ -42,10 +42,10 @@ const eventCellStyle = ({ borderColor, backgroundColor }: eventCellType) => Styl
   eventInfo: {
     ...FIRA_SANS_REGULAR.MD,
     color: COPPER_GREY[500],
-    marginTop: MARGIN.XS,
     marginRight: MARGIN.XS,
   },
   timeContainer: {
+    marginTop: MARGIN.XS,
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/styles/metrics.ts
+++ b/src/styles/metrics.ts
@@ -34,6 +34,7 @@ export const BORDER_RADIUS = {
 };
 
 export const ICON = {
+  XXS: 12,
   XS: 16,
   SM: 20,
   MD: 24,


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] Mes changements entrainent une incompatibilité avec l'ancienne version de l'api
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : auxiliaire

- Cas d'usage : l'icone "check" d'un horodatage (debut ou fin) sur la page agenda etait trop grosse pour Romain. Je l'ai raccourcis et épaissie 

- Comment tester ? : comparer l'icone avec la maquette figma

_Si tu as lu cette description, pense a réagir avec un :eye:_
