### PR TITLE
COM-2725 fix bug on customer profile

### DIFF
--- a/src/components/PersonEditionModal/index.tsx
+++ b/src/components/PersonEditionModal/index.tsx
@@ -71,7 +71,7 @@ const PersonEditionModal = ({
   };
 
   const sortOptions = (persons: FormattedUserType[]) => (
-    persons.sort((a, b) => (a.identity.firstname).localeCompare(b.identity.firstname))
+    persons.sort((a, b) => (a.formattedIdentity).localeCompare(b.formattedIdentity))
   );
 
   return (

--- a/src/types/UserType.ts
+++ b/src/types/UserType.ts
@@ -1,6 +1,6 @@
 export type UserType = {
   _id: string,
-  identity: { firstname: string, lastname: string, birthDate?: string },
+  identity: { firstname?: string, lastname: string, birthDate?: string },
   local?: { email?: string },
   picture?: { link: string },
   company?: { name: string },
@@ -12,7 +12,7 @@ export type UserType = {
 
 export type AuxiliaryType = {
   _id: UserType['_id'],
-  identity: UserType['identity'],
+  identity: UserType['identity'] & { firstname: string },
   contact?: UserType['contact'],
   picture?: UserType['picture'],
   contracts?: UserType['contracts'],


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning: -np

- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] Mes changements entrainent une incompatibilité avec l'ancienne version de l'api
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : auxiliaire

- Cas d'usage : je peux acceder a une fiche beneficiaire meme si celui-ci a un aidant sans prenom

- Comment tester ? : se creer un compte auxiliaire avec une intervention aujourd'hui. Ajouter au beneficiaire de l'intervention un aidant sans prenom. Essayez d'acceder a la page profile du beneficiaire sur l'application. 

_Si tu as lu cette description, pense a réagir avec un :eye:_
