### PR TITLE
COM-2765 - fix bug

### DIFF
--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -179,8 +179,8 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
 
         await Events.updateById(editedEvent._id, payload);
         setInitialState(editedEvent);
+        navigation.goBack();
       }
-      navigation.goBack();
     } catch (e) {
       console.error(e);
       if (e.response.status === 409) setApiErrorMessage(e.response.data.message);


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning: -np

- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] Mes changements entrainent une incompatibilité avec l'ancienne version de l'api
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : Auxiliaire

- Cas d'usage : 
    - lorsque j'édite l'heure d'une intervention, si l'heure est invalide et que j'enregistre, le message d'erreur s'affiche et je ne suis pas redirigé vers la page précédente 
    - Rmq: Bug présent uniquement sur Android. Sur IOS, le sélecteur d'heure permet de definir une date minimale pour l'heure de fin (heure de fin minimale = heure de debut de l'intervention) donc pas possible de definir une heure de fin antérieure a l'heure de début

- Comment tester ? :
   - editer l'heure d'une intervention de sorte a ce que l'heure de fin soit antérieure a l'heure de debut 
   - enregistrer
   - le message d'erreur s'affiche et on n'est pas redirigé vers la page précédente 

_Si tu as lu cette description, pense a réagir avec un :eye:_
