### PR TITLE
Com 2746

### DIFF
--- a/src/api/Events.ts
+++ b/src/api/Events.ts
@@ -3,7 +3,7 @@ import Environment from '../../environment';
 
 export type timeStampEventPayloadType = { action: string, reason?: string, startDate?: string, endDate?: string };
 type updateEventsPayloadType = { auxiliary: string, startDate: string, endDate: string, kmDuringEvent: number };
-type getEventsQueryType = { auxiliary: string, startDate: string, endDate: string, isCancelled: boolean };
+type getEventsQueryType = { auxiliary: string, startDate: string, endDate: string };
 
 export default {
   list: async (params: getEventsQueryType) => {

--- a/src/api/Events.ts
+++ b/src/api/Events.ts
@@ -2,7 +2,13 @@ import axiosLogged from './axios/logged';
 import Environment from '../../environment';
 
 export type timeStampEventPayloadType = { action: string, reason?: string, startDate?: string, endDate?: string };
-type updateEventsPayloadType = { auxiliary: string, startDate: string, endDate: string, kmDuringEvent: number };
+type updateEventsPayloadType = {
+  auxiliary: string,
+  startDate: string,
+  endDate: string,
+  kmDuringEvent?: number,
+  isCancelled?: boolean,
+};
 type getEventsQueryType = { auxiliary: string, startDate: string, endDate: string };
 
 export default {

--- a/src/components/CancelledEventInfos/index.tsx
+++ b/src/components/CancelledEventInfos/index.tsx
@@ -33,7 +33,7 @@ const CancelledEventInfos = ({ event } : CancelledEventInfosProps) => {
     } else if (event?.cancel?.condition === INVOICED_AND_NOT_PAID) setInvoicedIcon('check');
   }, [event?.cancel?.condition]);
 
-  const restoreEvent = async () => {
+  const uncancelEvent = async () => {
     try {
       setConfirmationLoading(true);
 
@@ -62,12 +62,12 @@ const CancelledEventInfos = ({ event } : CancelledEventInfosProps) => {
         <View style={styles.details}>
           <Text style={styles.infos}>Facturé au client</Text>
           <View style={styles.dashedLine}/>
-          <MaterialCommunityIcons name={invoicedIcon} color={COPPER_GREY[900]} size={ICON.XS}/>
+          <MaterialCommunityIcons name={invoicedIcon} color={COPPER_GREY[900]} size={ICON.MD} />
         </View>
         <View style={styles.details}>
           <Text style={styles.infos}>Payé à l&apos;auxiliaire</Text>
           <View style={styles.dashedLine}/>
-          <MaterialCommunityIcons name={paidIcon} color={COPPER_GREY[900]} size={ICON.XS}/>
+          <MaterialCommunityIcons name={paidIcon} color={COPPER_GREY[900]} size={ICON.MD} />
         </View>
       </View>
       {!event.isBilled && <>
@@ -78,7 +78,7 @@ const CancelledEventInfos = ({ event } : CancelledEventInfosProps) => {
           {!!error && <NiError message={error.message} />}
           <ConfirmationModal visible={confirmationModal} title="Confirmation" cancelText="Annuler" exitButton
             confirmText="Rétablir l'intervention" contentText="Êtes vous sûr(e) de vouloir rétablir l'intervention ?"
-            onPressConfirmButton={restoreEvent} onRequestClose={() => setConfirmationModal(false)}
+            onPressConfirmButton={uncancelEvent} onRequestClose={() => setConfirmationModal(false)}
             loading={confirmationLoading} onPressCancelButton={() => setConfirmationModal(false)} />
         </View>
       </>}

--- a/src/components/CancelledEventInfos/index.tsx
+++ b/src/components/CancelledEventInfos/index.tsx
@@ -1,0 +1,89 @@
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/core';
+import React, { useEffect, useReducer, useState } from 'react';
+import { Text, View } from 'react-native';
+import Events from '../../api/Events';
+import { CANCELLATION_REASONS, INVOICED_AND_NOT_PAID, INVOICED_AND_PAID } from '../../core/data/constants';
+import { errorReducer, initialErrorState, SET_ERROR } from '../../reducers/error';
+import { EventEditionStateType } from '../../screens/timeStamping/EventEdition/types';
+import { COPPER_GREY } from '../../styles/colors';
+import { ICON } from '../../styles/metrics';
+import { MaterialCommunityIconsType } from '../../types/IconType';
+import NiButton from '../form/SecondaryButton';
+import NiError from '../ErrorMessage';
+import ConfirmationModal from '../modals/ConfirmationModal';
+import styles from './styles';
+
+interface CancelledEventInfosProps {
+  event: EventEditionStateType
+}
+
+const CancelledEventInfos = ({ event } : CancelledEventInfosProps) => {
+  const [invoicedIcon, setInvoicedIcon] = useState<MaterialCommunityIconsType>('close');
+  const [paidIcon, setPaidIcon] = useState<MaterialCommunityIconsType>('close');
+  const [confirmationModal, setConfirmationModal] = useState<boolean>(false);
+  const [confirmationLoading, setConfirmationLoading] = useState<boolean>(false);
+  const [error, dispatchError] = useReducer(errorReducer, initialErrorState);
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    if (event?.cancel?.condition === INVOICED_AND_PAID) {
+      setInvoicedIcon('check');
+      setPaidIcon('check');
+    } else if (event?.cancel?.condition === INVOICED_AND_NOT_PAID) setInvoicedIcon('check');
+  }, [event?.cancel?.condition]);
+
+  const cancelCancellation = async () => {
+    try {
+      setConfirmationLoading(true);
+
+      await Events.updateById(
+        event._id,
+        { startDate: event.startDate, endDate: event.endDate, isCancelled: false, auxiliary: event.auxiliary._id }
+      );
+      navigation.goBack();
+    } catch (e) {
+      console.error(e);
+      dispatchError({ type: SET_ERROR, payload: 'Une erreur s\'est produite, veuillez réessayer ultérieurement.' });
+    } finally {
+      setConfirmationLoading(false);
+      setConfirmationModal(false);
+    }
+  };
+
+  return (
+    <>
+      <View style={styles.separator} />
+      <View style={styles.container}>
+        <Text style={styles.section}>Conditions d&apos;annulation</Text>
+        <Text style={styles.subsection}>Personne à l&apos;origine de l&apos;annulation</Text>
+        <Text style={styles.infos}>{CANCELLATION_REASONS.find(opt => opt.value === event?.cancel?.reason)?.label}</Text>
+        <Text style={styles.subsection}>Conditions de facturation</Text>
+        <View style={styles.details}>
+          <Text style={styles.infos}>Facturé au client</Text>
+          <View style={styles.dashedLine}/>
+          <MaterialCommunityIcons name={invoicedIcon} color={COPPER_GREY[900]} size={ICON.XS}/>
+        </View>
+        <View style={styles.details}>
+          <Text style={styles.infos}>Payé à l&apos;auxiliaire</Text>
+          <View style={styles.dashedLine}/>
+          <MaterialCommunityIcons name={paidIcon} color={COPPER_GREY[900]} size={ICON.XS}/>
+        </View>
+      </View>
+      {!event.isBilled && <>
+        <View style={styles.separator} />
+        <View style={styles.container}>
+          <NiButton title="Rétablir l&apos;intervention" style={styles.button} textStyle={styles.textButton}
+            onPress={() => setConfirmationModal(true)}/>
+          {!!error && <NiError message={error.message} />}
+          <ConfirmationModal visible={confirmationModal} title="Confirmation" cancelText="Annuler" exitButton
+            confirmText="Rétablir l'intervention" contentText="Êtes vous sûr(e) de vouloir rétablir l'intervention ?"
+            onPressConfirmButton={cancelCancellation} onRequestClose={() => setConfirmationModal(false)}
+            loading={confirmationLoading} onPressCancelButton={() => setConfirmationModal(false)} />
+        </View>
+      </>}
+    </>
+  );
+};
+
+export default CancelledEventInfos;

--- a/src/components/CancelledEventInfos/index.tsx
+++ b/src/components/CancelledEventInfos/index.tsx
@@ -30,8 +30,9 @@ const CancelledEventInfos = ({ event } : CancelledEventInfosProps) => {
     if (event?.cancel?.condition === INVOICED_AND_PAID) {
       setInvoicedIcon('check');
       setPaidIcon('check');
-    } else if (event?.cancel?.condition === INVOICED_AND_NOT_PAID) setInvoicedIcon('check');
-    else {
+    } else if (event?.cancel?.condition === INVOICED_AND_NOT_PAID) {
+      setInvoicedIcon('check');
+    } else {
       setInvoicedIcon('close');
       setPaidIcon('close');
     }

--- a/src/components/CancelledEventInfos/index.tsx
+++ b/src/components/CancelledEventInfos/index.tsx
@@ -31,6 +31,10 @@ const CancelledEventInfos = ({ event } : CancelledEventInfosProps) => {
       setInvoicedIcon('check');
       setPaidIcon('check');
     } else if (event?.cancel?.condition === INVOICED_AND_NOT_PAID) setInvoicedIcon('check');
+    else {
+      setInvoicedIcon('close');
+      setPaidIcon('close');
+    }
   }, [event?.cancel?.condition]);
 
   const uncancelEvent = async () => {

--- a/src/components/CancelledEventInfos/index.tsx
+++ b/src/components/CancelledEventInfos/index.tsx
@@ -33,7 +33,7 @@ const CancelledEventInfos = ({ event } : CancelledEventInfosProps) => {
     } else if (event?.cancel?.condition === INVOICED_AND_NOT_PAID) setInvoicedIcon('check');
   }, [event?.cancel?.condition]);
 
-  const cancelCancellation = async () => {
+  const restoreEvent = async () => {
     try {
       setConfirmationLoading(true);
 
@@ -78,7 +78,7 @@ const CancelledEventInfos = ({ event } : CancelledEventInfosProps) => {
           {!!error && <NiError message={error.message} />}
           <ConfirmationModal visible={confirmationModal} title="Confirmation" cancelText="Annuler" exitButton
             confirmText="Rétablir l'intervention" contentText="Êtes vous sûr(e) de vouloir rétablir l'intervention ?"
-            onPressConfirmButton={cancelCancellation} onRequestClose={() => setConfirmationModal(false)}
+            onPressConfirmButton={restoreEvent} onRequestClose={() => setConfirmationModal(false)}
             loading={confirmationLoading} onPressCancelButton={() => setConfirmationModal(false)} />
         </View>
       </>}

--- a/src/components/CancelledEventInfos/styles.ts
+++ b/src/components/CancelledEventInfos/styles.ts
@@ -1,0 +1,54 @@
+import { StyleSheet } from 'react-native';
+import { COPPER_GREY } from '../../styles/colors';
+import { FIRA_SANS_MEDIUM, FIRA_SANS_REGULAR } from '../../styles/fonts';
+import { BORDER_WIDTH, MARGIN, PADDING } from '../../styles/metrics';
+
+export default StyleSheet.create({
+  container: {
+    padding: PADDING.XL,
+  },
+  separator: {
+    width: '100%',
+    borderWidth: BORDER_WIDTH / 2,
+    borderColor: COPPER_GREY[200],
+    marginBottom: MARGIN.MD,
+  },
+  section: {
+    ...FIRA_SANS_MEDIUM.MD,
+    color: COPPER_GREY[900],
+    marginBottom: MARGIN.LG,
+  },
+  subsection: {
+    ...FIRA_SANS_REGULAR.SM,
+    color: COPPER_GREY[700],
+    marginVertical: MARGIN.MD,
+  },
+  infos: {
+    ...FIRA_SANS_REGULAR.SM,
+    color: COPPER_GREY[900],
+    marginBottom: MARGIN.MD,
+  },
+  dashedLine: {
+    borderRadius: 1,
+    borderStyle: 'dashed',
+    width: '50%',
+    height: 0,
+    borderColor: COPPER_GREY[300],
+    borderWidth: BORDER_WIDTH / 2,
+    marginVertical: MARGIN.SM,
+  },
+  details: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: PADDING.MD,
+  },
+  button: {
+    borderColor: COPPER_GREY[200],
+    backgroundColor: COPPER_GREY[50],
+  },
+  textButton: {
+    ...FIRA_SANS_REGULAR.MD,
+    color: COPPER_GREY[700],
+  },
+});

--- a/src/components/CancelledEventInfos/styles.ts
+++ b/src/components/CancelledEventInfos/styles.ts
@@ -1,36 +1,34 @@
 import { StyleSheet } from 'react-native';
 import { COPPER_GREY } from '../../styles/colors';
 import { FIRA_SANS_MEDIUM, FIRA_SANS_REGULAR } from '../../styles/fonts';
-import { BORDER_WIDTH, MARGIN, PADDING } from '../../styles/metrics';
+import { BORDER_RADIUS, BORDER_WIDTH, MARGIN, PADDING } from '../../styles/metrics';
 
 export default StyleSheet.create({
   container: {
-    paddingHorizontal: PADDING.XL,
-    paddingTop: PADDING.XL,
+    padding: PADDING.XL,
   },
   separator: {
     width: '100%',
     borderWidth: BORDER_WIDTH / 2,
     borderColor: COPPER_GREY[200],
-    marginVertical: MARGIN.MD,
+    marginTop: MARGIN.MD,
   },
   section: {
     ...FIRA_SANS_MEDIUM.MD,
     color: COPPER_GREY[900],
-    marginBottom: MARGIN.MD,
   },
   subsection: {
     ...FIRA_SANS_REGULAR.SM,
     color: COPPER_GREY[700],
-    marginVertical: MARGIN.MD,
-  },
-  infos: {
-    ...FIRA_SANS_REGULAR.SM,
-    color: COPPER_GREY[900],
+    marginTop: MARGIN.XL,
     marginBottom: MARGIN.MD,
   },
+  infos: {
+    ...FIRA_SANS_REGULAR.MD,
+    color: COPPER_GREY[900],
+  },
   dashedLine: {
-    borderRadius: 1,
+    borderRadius: BORDER_RADIUS.XS,
     borderStyle: 'dashed',
     width: '50%',
     height: 0,
@@ -42,7 +40,9 @@ export default StyleSheet.create({
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'space-between',
+    alignItems: 'center',
     paddingHorizontal: PADDING.MD,
+    paddingVertical: PADDING.SM,
   },
   button: {
     borderColor: COPPER_GREY[200],

--- a/src/components/CancelledEventInfos/styles.ts
+++ b/src/components/CancelledEventInfos/styles.ts
@@ -5,18 +5,19 @@ import { BORDER_WIDTH, MARGIN, PADDING } from '../../styles/metrics';
 
 export default StyleSheet.create({
   container: {
-    padding: PADDING.XL,
+    paddingHorizontal: PADDING.XL,
+    paddingTop: PADDING.XL,
   },
   separator: {
     width: '100%',
     borderWidth: BORDER_WIDTH / 2,
     borderColor: COPPER_GREY[200],
-    marginBottom: MARGIN.MD,
+    marginVertical: MARGIN.MD,
   },
   section: {
     ...FIRA_SANS_MEDIUM.MD,
     color: COPPER_GREY[900],
-    marginBottom: MARGIN.LG,
+    marginBottom: MARGIN.MD,
   },
   subsection: {
     ...FIRA_SANS_REGULAR.SM,

--- a/src/components/EventCell/index.tsx
+++ b/src/components/EventCell/index.tsx
@@ -139,8 +139,8 @@ const EventCell = ({ event }: TimeStampingProps) => {
             onPress={() => (eventInfos?.startDateTimeStamp ? requestPermission(false) : requestPermission(true)) }>
             <MaterialIcons name="qr-code-2" size={ICON.LG} color={COPPER[500]} />
           </TouchableOpacity>}
-        {eventInfos.isCancelled && <View style={style.textContainer}>
-          <Text style={style.text}>annulé</Text>
+        {eventInfos.isCancelled && <View style={style.cancelledEventContainer}>
+          <Text style={style.cancelledEvent}>annulé</Text>
         </View>}
       </TouchableOpacity>
       <CameraAccessModal visible={modalVisible} onRequestClose={() => setModalVisible(false)}

--- a/src/components/EventCell/index.tsx
+++ b/src/components/EventCell/index.tsx
@@ -132,13 +132,14 @@ const EventCell = ({ event }: TimeStampingProps) => {
             {eventInfos.endDateTimeStamp &&
               <MaterialCommunityIcons name="check-bold" color={COPPER[500]} size={ICON.XXS} />}
           </View>
-          <Text style={style.eventInfo}>{eventInfos.address.toLocaleLowerCase()}</Text>
+          {!!eventInfos.address && <Text style={style.eventInfo}>{eventInfos.address.toLocaleLowerCase()}</Text>}
         </View>
-        {!eventInfos.endDateTimeStamp && eventInfos.type === INTERVENTION &&
+        {!eventInfos.endDateTimeStamp && eventInfos.type === INTERVENTION && !eventInfos.isCancelled &&
           <TouchableOpacity hitSlop={hitSlop}
             onPress={() => (eventInfos?.startDateTimeStamp ? requestPermission(false) : requestPermission(true)) }>
             <MaterialIcons name="qr-code-2" size={ICON.LG} color={COPPER[500]} />
           </TouchableOpacity>}
+        {eventInfos.isCancelled && <Text>Annulé</Text>}
       </TouchableOpacity>
       <CameraAccessModal visible={modalVisible} onRequestClose={() => setModalVisible(false)}
         onPressAskAgain={askPermissionAgain} goToManualTimeStamping={goToManualTimeStamping} />

--- a/src/components/EventCell/index.tsx
+++ b/src/components/EventCell/index.tsx
@@ -118,7 +118,7 @@ const EventCell = ({ event }: TimeStampingProps) => {
   };
 
   return (
-    <View>
+    <>
       <TouchableOpacity style={style.cell} onPress={goToEventEdition}>
         <View style={style.infoContainer}>
           <Text style={style.eventTitle}>{cellInfos.title}</Text>
@@ -139,11 +139,13 @@ const EventCell = ({ event }: TimeStampingProps) => {
             onPress={() => (eventInfos?.startDateTimeStamp ? requestPermission(false) : requestPermission(true)) }>
             <MaterialIcons name="qr-code-2" size={ICON.LG} color={COPPER[500]} />
           </TouchableOpacity>}
-        {eventInfos.isCancelled && <Text>Annulé</Text>}
+        {eventInfos.isCancelled && <View style={style.textContainer}>
+          <Text style={style.text}>annulé</Text>
+        </View>}
       </TouchableOpacity>
       <CameraAccessModal visible={modalVisible} onRequestClose={() => setModalVisible(false)}
         onPressAskAgain={askPermissionAgain} goToManualTimeStamping={goToManualTimeStamping} />
-    </View>
+    </>
   );
 };
 

--- a/src/components/EventCell/reducers/events.ts
+++ b/src/components/EventCell/reducers/events.ts
@@ -13,6 +13,7 @@ type EventStateType = {
   endDateTimeStamp: boolean,
   type: string,
   internalHourName: string,
+  isCancelled: boolean,
 };
 
 type EventActionType = {
@@ -33,6 +34,7 @@ const initialState = {
   endDateTimeStamp: false,
   type: '',
   internalHourName: '',
+  isCancelled: false,
 };
 const SET_EVENT_INFOS = 'setEventInfos';
 const SET_TIMESTAMPED_INFOS = 'setTimeStampedInfos';
@@ -54,6 +56,7 @@ const eventReducer = (state: EventStateType, action: EventActionType): EventStat
         endDate: action.payload.event?.endDate || null,
         type: action.payload.event?.type || '',
         internalHourName: action.payload.event?.internalHour?.name || '',
+        isCancelled: action.payload.event?.isCancelled || false,
       };
     case SET_TIMESTAMPED_INFOS:
       return {

--- a/src/components/EventCell/styles.ts
+++ b/src/components/EventCell/styles.ts
@@ -16,8 +16,8 @@ export type eventCellStyleType = {
   eventTitle: object,
   eventInfo: object,
   timeContainer: object,
-  text: object,
-  textContainer: Object,
+  cancelledEvent: object,
+  cancelledEventContainer: Object,
 };
 
 const eventCellStyle = ({ borderColor, backgroundColor }: eventCellType) => StyleSheet.create({
@@ -52,14 +52,14 @@ const eventCellStyle = ({ borderColor, backgroundColor }: eventCellType) => Styl
     flexDirection: 'row',
     alignItems: 'center',
   },
-  textContainer: {
+  cancelledEventContainer: {
     backgroundColor: COPPER_GREY[200],
     borderRadius: BORDER_RADIUS.LG,
     paddingHorizontal: PADDING.MD,
     paddingVertical: PADDING.SM,
     height: '40%',
   },
-  text: {
+  cancelledEvent: {
     ...FIRA_SANS_REGULAR.SM,
     color: COPPER[800],
   },

--- a/src/components/EventCell/styles.ts
+++ b/src/components/EventCell/styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { COPPER_GREY } from '../../styles/colors';
+import { COPPER, COPPER_GREY } from '../../styles/colors';
 import { FIRA_SANS_BOLD, FIRA_SANS_REGULAR } from '../../styles/fonts';
 import { BORDER_RADIUS, BORDER_WIDTH, MARGIN, PADDING } from '../../styles/metrics';
 
@@ -16,6 +16,8 @@ export type eventCellStyleType = {
   eventTitle: object,
   eventInfo: object,
   timeContainer: object,
+  text: object,
+  textContainer: Object,
 };
 
 const eventCellStyle = ({ borderColor, backgroundColor }: eventCellType) => StyleSheet.create({
@@ -49,6 +51,17 @@ const eventCellStyle = ({ borderColor, backgroundColor }: eventCellType) => Styl
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  textContainer: {
+    backgroundColor: COPPER_GREY[200],
+    borderRadius: BORDER_RADIUS.LG,
+    paddingHorizontal: PADDING.MD,
+    paddingVertical: PADDING.SM,
+    height: '40%',
+  },
+  text: {
+    ...FIRA_SANS_REGULAR.SM,
+    color: COPPER[800],
   },
 });
 

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -19,9 +19,10 @@ type NiSelectProps = {
   options: OptionType[],
   selectedItem: string,
   onItemSelect: (item: string) => void,
+  disabled?: boolean,
 }
 
-const Select = ({ title, caption, options, selectedItem, onItemSelect }: NiSelectProps) => {
+const Select = ({ title, caption, options, selectedItem, onItemSelect, disabled = false }: NiSelectProps) => {
   const [displaySelect, setDisplaySelect] = useState<boolean>(false);
 
   const onPressCell = () => setDisplaySelect(prevValue => !prevValue);
@@ -52,7 +53,8 @@ const Select = ({ title, caption, options, selectedItem, onItemSelect }: NiSelec
     <>
       <Text style={styles.sectionText}>{caption}</Text>
       <View>
-        <TouchableOpacity style={[styles.optionCell, displaySelect && styles.selectedCell]} onPress={onPressCell}>
+        <TouchableOpacity style={[styles.optionCell, displaySelect && styles.selectedCell]} onPress={onPressCell}
+          disabled={disabled}>
           <Text style={styles.optionText}>{(options.find(item => item.value === selectedItem))?.label || ''}</Text>
           {displaySelect
             ? <FeatherButton name='chevron-up' onPress={onPressCell} />

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -57,8 +57,8 @@ const Select = ({ title, caption, options, selectedItem, onItemSelect, disabled 
           disabled={disabled}>
           <Text style={styles.optionText}>{(options.find(item => item.value === selectedItem))?.label || ''}</Text>
           {displaySelect
-            ? <FeatherButton name='chevron-up' onPress={onPressCell} />
-            : <FeatherButton name='chevron-down' onPress={onPressCell} />}
+            ? <FeatherButton name='chevron-up' onPress={onPressCell} disabled={disabled} />
+            : <FeatherButton name='chevron-down' onPress={onPressCell} disabled={disabled} />}
         </TouchableOpacity>
         {displaySelect && <Shadow />}
       </View>

--- a/src/components/form/SecondaryButton/index.tsx
+++ b/src/components/form/SecondaryButton/index.tsx
@@ -16,11 +16,12 @@ const SecondaryButton = ({
   title,
   onPress = () => {},
   style = {},
+  textStyle = {},
   loading = false,
   disabled = false,
 } : SecondaryButtonProps) => (
   <TouchableOpacity style={[styles.button, style]} onPress={onPress} disabled={loading || disabled} testID={title}>
-    {!loading && <Text style={styles.textButton}>{title}</Text>}
+    {!loading && <Text style={[styles.textButton, textStyle]}>{title}</Text>}
     {loading && <ActivityIndicator style={commonStyle.disabled} color={WHITE} size="small" />}
   </TouchableOpacity>
 );

--- a/src/components/form/SecondaryButton/index.tsx
+++ b/src/components/form/SecondaryButton/index.tsx
@@ -8,6 +8,7 @@ interface SecondaryButtonProps {
   title: string,
   onPress?: () => void,
   style?: Object,
+  textStyle?: Object,
   loading?: boolean,
   disabled?: boolean,
 }

--- a/src/core/data/constants.ts
+++ b/src/core/data/constants.ts
@@ -59,6 +59,19 @@ export const EVENT_TRANSPORT_OPTIONS = [
   { label: 'Véhicule d\'entreprise', value: COMPANY_TRANSPORT },
 ];
 
+// CANCELLATION OPTIONS
+export const INVOICED_AND_PAID = 'invoiced_and_paid';
+export const INVOICED_AND_NOT_PAID = 'invoiced_and_not_paid';
+export const NOT_INVOICED_AND_NOT_PAID = 'not_invoiced_and_not_paid';
+
+// CANCELLATION REASONS
+export const CUSTOMER_INITIATIVE = 'customer_initiative';
+export const AUXILIARY_INITIATIVE = 'auxiliary_initiative';
+export const CANCELLATION_REASONS = [
+  { label: 'Initiative du/de la client(e)', value: CUSTOMER_INITIATIVE },
+  { label: 'Initiative de l\'intervenant(e)', value: AUXILIARY_INITIATIVE },
+];
+
 // ERROR
 export const ERROR = 'error';
 export const WARNING = 'warning';

--- a/src/core/data/constants.ts
+++ b/src/core/data/constants.ts
@@ -68,8 +68,8 @@ export const NOT_INVOICED_AND_NOT_PAID = 'not_invoiced_and_not_paid';
 export const CUSTOMER_INITIATIVE = 'customer_initiative';
 export const AUXILIARY_INITIATIVE = 'auxiliary_initiative';
 export const CANCELLATION_REASONS = [
-  { label: 'Initiative du/de la client(e)', value: CUSTOMER_INITIATIVE },
-  { label: 'Initiative de l\'intervenant(e)', value: AUXILIARY_INITIATIVE },
+  { label: 'Client(e)', value: CUSTOMER_INITIATIVE },
+  { label: 'Intervenant(e)', value: AUXILIARY_INITIATIVE },
 ];
 
 // ERROR

--- a/src/screens/Profile/styles.ts
+++ b/src/screens/Profile/styles.ts
@@ -11,7 +11,7 @@ export default StyleSheet.create({
     backgroundColor: COPPER_GREY[50],
   },
   sectionDelimiter: {
-    borderWidth: BORDER_WIDTH,
+    borderWidth: BORDER_WIDTH / 2,
     borderColor: COPPER_GREY[200],
     marginVertical: MARGIN.XL,
   },

--- a/src/screens/timeStamping/Agenda/index.tsx
+++ b/src/screens/timeStamping/Agenda/index.tsx
@@ -50,7 +50,6 @@ const Agenda = () => {
             auxiliary: loggedUser._id,
             startDate: CompaniDate().startOf('day').toISO(),
             endDate: CompaniDate().endOf('day').toISO(),
-            isCancelled: false,
           };
           const fetchedEvents = await Events.list(params);
 

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -25,7 +25,7 @@ import NiPersonSelect from '../../../components/PersonSelect';
 import EventFieldEdition from '../../../components/EventFieldEdition';
 import ErrorMessage from '../../../components/ErrorMessage';
 import NiSelect from '../../../components/Select';
-import CancelledEventEditionInfos from '../../../components/CancelledEventEditionInfos';
+import CancelledEventInfos from '../../../components/CancelledEventInfos';
 import { COPPER, COPPER_GREY, WHITE } from '../../../styles/colors';
 import { ICON, KEYBOARD_PADDING_TOP } from '../../../styles/metrics';
 import styles from './styles';
@@ -321,46 +321,48 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
           {subtitle.text}
         </Text>}
       <KeyboardAwareScrollView extraScrollHeight={KEYBOARD_PADDING_TOP} enableOnAndroid style={styles.screen}>
-        <ScrollView contentContainerStyle={styles.container}>
-          <Text style={styles.name}>{editedEvent.title}</Text>
-          {editedEvent.type === INTERVENTION &&
-            <TouchableOpacity style={styles.customerProfileButton} disabled={loading}
-              onPress={() => goToCustomerProfile(editedEvent.customer._id)}>
-              <Text style={styles.customerProfileButtonTitle}>Fiche bénéficiaire</Text>
-              <Feather name="chevron-right" color={COPPER[500]}/>
-            </TouchableOpacity>}
-          {editedEvent.address && <View style={styles.addressContainer}>
-            <Feather name="map-pin" size={ICON.SM} color={COPPER_GREY[500]} />
-            <View>
-              <Text style={styles.addressText}>{formatAddress(editedEvent)}</Text>
-              <Text style={styles.addressText}>{formatZipCodeAndCity(editedEvent)}</Text>
-            </View>
-          </View>}
-          <EventDateTimeEdition event={editedEvent} eventEditionDispatch={editedEventDispatch}
-            refreshHistories={refreshHistories} loading={loading} dateErrorMessage={dateErrorMessage || ''}
-            style={styles.date} />
-          {editedEvent.type === INTERVENTION &&
-          <>
-            <NiPersonSelect title={'Intervenant'} person={formatAuxiliary(editedEvent.auxiliary)}
-              personOptions={activeAuxiliaries} onSelectPerson={onSelectPerson} isEditable={isAuxiliaryEditable}
-              errorMessage={'Vous ne pouvez pas modifier l\'intervenant d\'une intervention horodatée ou facturée.'}
-              modalPlaceHolder="Chercher un intervenant" />
-            <NiSelect selectedItem={editedEvent.transportMode} caption="Transport pour aller à l&apos;intervention"
-              options={EVENT_TRANSPORT_OPTIONS} onItemSelect={selectTransportMode} title="transport" />
-            <EventFieldEdition text={editedEvent.kmDuringEvent ? editedEvent.kmDuringEvent.toString() : ''}
-              disabled={!!editedEvent.isBilled} inputTitle={'Déplacement véhiculé avec bénéficiaire'} type={NUMBER}
-              buttonTitle="Ajouter un déplacement véhiculé avec bénéficiaire" onChangeText={onChangeKmDuringEvent}
-              buttonIcon={<MaterialCommunityIcons name='truck-outline' size={24} color={COPPER[600]} suffix={'km'} />}
-              errorMessage={kmDuringEventErrorMessage || ''} />
-          </>}
-          {editedEvent.type === INTERNAL_HOUR &&
-            <NiSelect caption="Type d’heure interne" options={internalHourOptions} onItemSelect={selectInternalHourType}
-              selectedItem={editedEvent.internalHour} title="Heure interne" />}
-          <EventFieldEdition text={editedEvent.misc} inputTitle="Note" disabled={!!editedEvent.isBilled}
-            buttonTitle="Ajouter une note" multiline
-            onChangeText={(value: string) => editedEventDispatch({ type: SET_FIELD, payload: { misc: value || '' } })}
-            buttonIcon={<MaterialIcons name={'playlist-add'} size={24} color={COPPER[600]} />} />
-          {editedEvent.isCancelled && <CancelledEventEditionInfos cancel={editedEvent.cancel} />}
+        <ScrollView>
+          <View style={styles.container}>
+            <Text style={styles.name}>{editedEvent.title}</Text>
+            {editedEvent.type === INTERVENTION &&
+              <TouchableOpacity style={styles.customerProfileButton} disabled={loading}
+                onPress={() => goToCustomerProfile(editedEvent.customer._id)}>
+                <Text style={styles.customerProfileButtonTitle}>Fiche bénéficiaire</Text>
+                <Feather name="chevron-right" color={COPPER[500]}/>
+              </TouchableOpacity>}
+            {editedEvent.address && <View style={styles.addressContainer}>
+              <Feather name="map-pin" size={ICON.SM} color={COPPER_GREY[500]} />
+              <View>
+                <Text style={styles.addressText}>{formatAddress(editedEvent)}</Text>
+                <Text style={styles.addressText}>{formatZipCodeAndCity(editedEvent)}</Text>
+              </View>
+            </View>}
+            <EventDateTimeEdition event={editedEvent} eventEditionDispatch={editedEventDispatch}
+              refreshHistories={refreshHistories} loading={loading} dateErrorMessage={dateErrorMessage || ''}
+              style={styles.date} />
+            {editedEvent.type === INTERVENTION &&
+            <>
+              <NiPersonSelect title={'Intervenant'} person={formatAuxiliary(editedEvent.auxiliary)}
+                personOptions={activeAuxiliaries} onSelectPerson={onSelectPerson} isEditable={isAuxiliaryEditable}
+                errorMessage={'Vous ne pouvez pas modifier l\'intervenant d\'une intervention horodatée ou facturée.'}
+                modalPlaceHolder="Chercher un intervenant" />
+              <NiSelect selectedItem={editedEvent.transportMode} caption="Transport pour aller à l&apos;intervention"
+                options={EVENT_TRANSPORT_OPTIONS} onItemSelect={selectTransportMode} title="transport" />
+              <EventFieldEdition text={editedEvent.kmDuringEvent ? editedEvent.kmDuringEvent.toString() : ''}
+                disabled={!!editedEvent.isBilled} inputTitle={'Déplacement véhiculé avec bénéficiaire'} type={NUMBER}
+                buttonTitle="Ajouter un déplacement véhiculé avec bénéficiaire" onChangeText={onChangeKmDuringEvent}
+                buttonIcon={<MaterialCommunityIcons name='truck-outline' size={24} color={COPPER[600]} suffix={'km'} />}
+                errorMessage={kmDuringEventErrorMessage || ''} />
+            </>}
+            {editedEvent.type === INTERNAL_HOUR &&
+              <NiSelect caption="Type d’heure interne" options={internalHourOptions}
+                onItemSelect={selectInternalHourType} selectedItem={editedEvent.internalHour} title="Heure interne" />}
+            <EventFieldEdition text={editedEvent.misc} inputTitle="Note" disabled={!!editedEvent.isBilled}
+              buttonTitle="Ajouter une note" multiline
+              onChangeText={(value: string) => editedEventDispatch({ type: SET_FIELD, payload: { misc: value || '' } })}
+              buttonIcon={<MaterialIcons name={'playlist-add'} size={24} color={COPPER[600]} />} />
+          </View>
+          {editedEvent.isCancelled && <CancelledEventInfos event={editedEvent} />}
           <ConfirmationModal onPressConfirmButton={onConfirmExit} onPressCancelButton={() => setExitModal(false)}
             visible={exitModal} contentText="Voulez-vous supprimer les modifications apportées à cet événement ?"
             cancelText="Poursuivre les modifications" confirmText="Supprimer" />

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -99,7 +99,7 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
     kmDuringEvent: false,
   });
   const [internalHourOptions, setInternalHourOptions] = useState<InternalHourOptionsType[]>([]);
-  const [subHeader, setSubHeader] = useState<subHeaderType>({ text: '', bgColor: '', textColor: '' });
+  const [subHeader, setSubHeader] = useState<subHeaderType>({ text: '', bgColor: WHITE, textColor: WHITE });
 
   const reducer = (state: EventEditionStateType, action: EventEditionActionType): EventEditionStateType => {
     const changeEndHourOnStartHourChange = () => {

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -306,7 +306,7 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
       } else {
         payload = { text: 'Intervention facturée', bgColor: COPPER[400], textColor: WHITE };
       }
-    } else if (editedEvent.isCancelled && !editedEvent.isBilled) {
+    } else if (editedEvent.isCancelled) {
       payload = { text: 'Intervention annulée', bgColor: COPPER_GREY[200], textColor: COPPER_GREY[700] };
     }
 

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -45,7 +45,7 @@ type InternalHourOptionsType = {
   value: string,
 };
 
-type subtitleType = {
+type subHeaderType = {
   text: string,
   bgColor: string,
   textColor: string,
@@ -99,7 +99,7 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
     kmDuringEvent: false,
   });
   const [internalHourOptions, setInternalHourOptions] = useState<InternalHourOptionsType[]>([]);
-  const [subtitle, setSubtitle] = useState<subtitleType>({ text: '', bgColor: WHITE, textColor: WHITE });
+  const [subHeader, setSubHeader] = useState<subHeaderType>({ text: '', bgColor: '', textColor: '' });
 
   const reducer = (state: EventEditionStateType, action: EventEditionActionType): EventEditionStateType => {
     const changeEndHourOnStartHourChange = () => {
@@ -301,24 +301,25 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
   useEffect(() => {
     let payload;
     if (editedEvent.isBilled) {
+      payload = { bgColor: COPPER[400], textColor: WHITE };
       if (editedEvent.isCancelled) {
-        payload = { text: 'Intervention annulée et facturée', bgColor: COPPER[400], textColor: WHITE };
+        payload = { ...payload, text: 'Intervention annulée et facturée' };
       } else {
-        payload = { text: 'Intervention facturée', bgColor: COPPER[400], textColor: WHITE };
+        payload = { ...payload, text: 'Intervention facturée' };
       }
     } else if (editedEvent.isCancelled) {
       payload = { text: 'Intervention annulée', bgColor: COPPER_GREY[200], textColor: COPPER_GREY[700] };
     }
 
-    if (payload) setSubtitle(payload);
+    if (payload) setSubHeader(payload);
   }, [editedEvent.isBilled, editedEvent.isCancelled]);
 
   return (
     <>
       <NiHeader onPressIcon={onLeave} title={headerTitle} loading={loading} onPressButton={onSave} />
       {(editedEvent.isBilled || editedEvent.isCancelled) &&
-        <Text style={[styles.billedHeader, { backgroundColor: subtitle.bgColor, color: subtitle.textColor }]}>
-          {subtitle.text}
+        <Text style={[styles.billedHeader, { backgroundColor: subHeader.bgColor, color: subHeader.textColor }]}>
+          {subHeader.text}
         </Text>}
       <KeyboardAwareScrollView extraScrollHeight={KEYBOARD_PADDING_TOP} enableOnAndroid style={styles.screen}>
         <ScrollView>

--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -316,7 +316,8 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
 
   return (
     <>
-      <NiHeader onPressIcon={onLeave} title={headerTitle} loading={loading} onPressButton={onSave} />
+      <NiHeader onPressIcon={onLeave} title={headerTitle} loading={loading} onPressButton={onSave}
+        disabled={editedEvent.isBilled} />
       {(editedEvent.isBilled || editedEvent.isCancelled) &&
         <Text style={[styles.billedHeader, { backgroundColor: subHeader.bgColor, color: subHeader.textColor }]}>
           {subHeader.text}
@@ -348,7 +349,8 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
                 errorMessage={'Vous ne pouvez pas modifier l\'intervenant d\'une intervention horodatée ou facturée.'}
                 modalPlaceHolder="Chercher un intervenant" />
               <NiSelect selectedItem={editedEvent.transportMode} caption="Transport pour aller à l&apos;intervention"
-                options={EVENT_TRANSPORT_OPTIONS} onItemSelect={selectTransportMode} title="transport" />
+                options={EVENT_TRANSPORT_OPTIONS} onItemSelect={selectTransportMode} title="transport"
+                disabled={editedEvent.isBilled} />
               <EventFieldEdition text={editedEvent.kmDuringEvent ? editedEvent.kmDuringEvent.toString() : ''}
                 disabled={!!editedEvent.isBilled} inputTitle={'Déplacement véhiculé avec bénéficiaire'} type={NUMBER}
                 buttonTitle="Ajouter un déplacement véhiculé avec bénéficiaire" onChangeText={onChangeKmDuringEvent}

--- a/src/screens/timeStamping/EventEdition/styles.ts
+++ b/src/screens/timeStamping/EventEdition/styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { COPPER, COPPER_GREY, WHITE } from '../../../styles/colors';
+import { COPPER, COPPER_GREY } from '../../../styles/colors';
 import { FIRA_SANS_BLACK, FIRA_SANS_REGULAR } from '../../../styles/fonts';
 import { MARGIN, PADDING } from '../../../styles/metrics';
 
@@ -13,8 +13,6 @@ export default StyleSheet.create({
   },
   billedHeader: {
     ...FIRA_SANS_REGULAR.MD,
-    backgroundColor: COPPER[400],
-    color: WHITE,
     textAlign: 'center',
     paddingVertical: PADDING.MD,
   },

--- a/src/screens/timeStamping/EventEdition/types.ts
+++ b/src/screens/timeStamping/EventEdition/types.ts
@@ -11,6 +11,8 @@ export type EventEditionStateType = {
   startDateTimeStamp?: EventType['startDateTimeStamp'],
   endDateTimeStamp?: EventType['endDateTimeStamp'],
   isBilled?: EventType['isBilled'],
+  isCancelled?: EventType['isCancelled'],
+  cancel?: EventType['cancel'],
   auxiliary: EventType['auxiliary'],
   company: EventType['company'],
   misc: EventType['misc'],

--- a/src/types/EventType.ts
+++ b/src/types/EventType.ts
@@ -19,6 +19,7 @@ export type EventType = {
   startDateTimeStamp?: boolean,
   endDateTimeStamp?: boolean,
   isBilled?: boolean,
+  isCancelled?: boolean,
   auxiliary: UserType,
   company: string,
   misc: string,

--- a/src/types/EventType.ts
+++ b/src/types/EventType.ts
@@ -20,6 +20,7 @@ export type EventType = {
   endDateTimeStamp?: boolean,
   isBilled?: boolean,
   isCancelled?: boolean,
+  cancel?: { condition: string, reason: string },
   auxiliary: UserType,
   company: string,
   misc: string,

--- a/src/types/IconType.ts
+++ b/src/types/IconType.ts
@@ -1,1 +1,3 @@
 export type FeatherType = 'eye-off' | 'eye' | 'x-circle' | 'arrow-left' | 'chevron-down' | 'x' | 'chevron-up';
+
+export type MaterialCommunityIconsType = 'check' | 'close';


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning: -np

- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] Mes changements entrainent une incompatibilité avec l'ancienne version de l'api
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : auxiliaire

- Cas d'usage : Sur l'agenda, j'ai accès aux interventions annulées et sur la page d'édition, je vois les informations d'annulation.

- Comment tester ? :
   - annuler une intervention depuis la webApp
       - sur l'agenda: verifier que l'intervention est marquée comme annulée
       - sur la page d'édition:  verifier que le bandeau `intervention annulée` apparait sous le header, que les informations d'annulation figurent en bas de la page et que le bouton `rétablir l'intervention` apparait
   - rétablir l'intervention
       - verifier que l'intervention n'est plus annulée 
  - annuler un intervention et la facturer 
       - sur l'agenda: verifier que l'intervention est marquée comme annulée
       - sur la page d'édition:  vérifier que le bandeau `intervention annulée` apparait sous le header, que les informations d'annulation figurent en bas de la page et que le bouton `rétablir l'intervention` n'apparait pas
  - facturer une intervention
       -  sur la page d'édition:  vérifier que le bandeau `intervention facturée` apparait sous le header
 