### PR TITLE
COM-2746 - add isCancelled to eventPayload

### DIFF
--- a/src/screens/timeStamping/EventEdition/index.tsx
+++ b/src/screens/timeStamping/EventEdition/index.tsx
@@ -178,7 +178,10 @@ const EventEdition = ({ route, navigation }: EventEditionProps) => {
       setIsValidationAttempted(true);
 
       if (isValid) {
-        const pickedFields = pick(editedEvent, ['startDate', 'endDate', 'misc', 'transportMode', 'internalHour']);
+        const pickedFields = pick(
+          editedEvent,
+          ['startDate', 'endDate', 'misc', 'transportMode', 'internalHour', 'isCancelled']
+        );
         const payload = {
           auxiliary: editedEvent.auxiliary._id,
           kmDuringEvent: Number.parseFloat(editedEvent.kmDuringEvent) || 0,


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning: -np

- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] Mes changements entrainent une incompatibilité avec l'ancienne version de l'api
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : auxiliaire

- Cas d'usage : fix du bug remonté par Sophie (cf commentaires du ticket)

- Comment tester ? 
   - depuis la webapp, annuler une intervention 
   - Cote mobile: 
     - vérifier que l'on voit bien les 2 icônes correspondant aux conditions d'annulation + la personne a l'origine de l'annulation
     -  editer l'heure de l'intervention et d'autres champs
     - revenir sur la page d'edition d'intervention et verifier que les infos d'annulation sont tjs affichées 
   - Sur la webapp: verifier que le planning s'affiche correctement sur la semaine de l'intervention

_Si tu as lu cette description, pense a réagir avec un :eye:_
