### PR TITLE
Com 2873

### DIFF
--- a/src/components/EventCell/index.tsx
+++ b/src/components/EventCell/index.tsx
@@ -11,7 +11,7 @@ import { COPPER, WHITE } from '../../styles/colors';
 import { hitSlop, ICON } from '../../styles/metrics';
 import styles, { eventCellStyleType } from './styles';
 import { eventReducer, initialState, SET_EVENT_INFOS, SET_TIMESTAMPED_INFOS } from './reducers/events';
-import { cellReducer, initialCellStyle, SET_INTERNAL_HOUR_INFOS, SET_INTERVENTION_INFOS } from './reducers/cells';
+import { cellReducer, initialCellStyle, SET_INTERNAL_HOUR_INFOS, SET_INTERVENTION_INFOS, SET_UNAVAILABILITY_INFOS } from './reducers/cells';
 
 interface TimeStampingProps {
   event: EventType,
@@ -45,6 +45,7 @@ const EventCell = ({ event }: TimeStampingProps) => {
   useEffect(() => {
     const payload = eventInfos;
     if (eventInfos.type === INTERVENTION) cellInfosDispatch({ type: SET_INTERVENTION_INFOS, payload });
+    else if (eventInfos.type === UNAVAILABILITY) cellInfosDispatch({ type: SET_UNAVAILABILITY_INFOS, payload });
     else cellInfosDispatch({ type: SET_INTERNAL_HOUR_INFOS, payload });
   }, [eventInfos]);
 

--- a/src/components/EventCell/index.tsx
+++ b/src/components/EventCell/index.tsx
@@ -3,7 +3,7 @@ import { View, Text, Alert, TouchableOpacity } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { Camera } from 'expo-camera';
 import { MaterialIcons, MaterialCommunityIcons } from '@expo/vector-icons';
-import { TIMESTAMPING_ACTION_TYPE_LIST, GRANTED, INTERVENTION } from '../../core/data/constants';
+import { TIMESTAMPING_ACTION_TYPE_LIST, GRANTED, INTERVENTION, UNAVAILABILITY } from '../../core/data/constants';
 import CompaniDate from '../../core/helpers/dates/companiDates';
 import { EventType, EventHistoryType } from '../../types/EventType';
 import CameraAccessModal from '../modals/CameraAccessModal';

--- a/src/components/EventCell/reducers/cells.ts
+++ b/src/components/EventCell/reducers/cells.ts
@@ -1,9 +1,10 @@
 import { formatIdentity } from '../../../core/helpers/utils';
-import { COPPER, WHITE } from '../../../styles/colors';
+import { COPPER, COPPER_GREY, WHITE } from '../../../styles/colors';
 import { EventStateType } from './events';
 
 const SET_INTERVENTION_INFOS = 'set_intervention_infos';
 const SET_INTERNAL_HOUR_INFOS = 'set_internal_hour_infos';
+const SET_UNAVAILABILITY_INFOS = 'set_unavailability_infos';
 
 type cellStateType = {
   title: string,
@@ -28,9 +29,11 @@ const cellReducer = (state: cellStateType, action: cellActionType): cellStateTyp
       return { title: formatIdentity(identity, 'FL'), borderColor: COPPER[100], backgroundColor: WHITE };
     case SET_INTERNAL_HOUR_INFOS:
       return { title: action.payload.internalHourName, borderColor: COPPER[400], backgroundColor: WHITE };
+    case SET_UNAVAILABILITY_INFOS:
+      return { title: 'Indispo', borderColor: COPPER_GREY[400], backgroundColor: COPPER_GREY[100] };
     default:
       return state;
   }
 };
 
-export { cellReducer, initialCellStyle, SET_INTERVENTION_INFOS, SET_INTERNAL_HOUR_INFOS };
+export { cellReducer, initialCellStyle, SET_INTERVENTION_INFOS, SET_INTERNAL_HOUR_INFOS, SET_UNAVAILABILITY_INFOS };

--- a/src/core/data/constants.ts
+++ b/src/core/data/constants.ts
@@ -27,6 +27,7 @@ export const TIME = 'time';
 // PLANNING
 export const INTERVENTION: EventTypeEnum = 'intervention';
 export const INTERNAL_HOUR: EventTypeEnum = 'internal_hour';
+export const UNAVAILABILITY: EventTypeEnum = 'unavailability';
 
 // CIVILITY
 export const MISTER : string = 'mr';

--- a/src/screens/timeStamping/Agenda/index.tsx
+++ b/src/screens/timeStamping/Agenda/index.tsx
@@ -4,7 +4,7 @@ import { useFocusEffect } from '@react-navigation/native';
 import commonStyle from '../../../styles/common';
 import Events from '../../../api/Events';
 import { Context as AuthContext } from '../../../context/AuthContext';
-import { ACTIVE_STATE, INTERNAL_HOUR, INTERVENTION } from '../../../core/data/constants';
+import { ACTIVE_STATE, INTERNAL_HOUR, INTERVENTION, UNAVAILABILITY } from '../../../core/data/constants';
 import { formatWordToPlural, ascendingSortArray } from '../../../core/helpers/utils';
 import CompaniDate from '../../../core/helpers/dates/companiDates';
 import EventCell from '../../../components/EventCell';
@@ -54,7 +54,7 @@ const Agenda = () => {
           const fetchedEvents = await Events.list(params);
 
           const filteredEvents = fetchedEvents
-            .filter((ev: EventType) => [INTERVENTION, INTERNAL_HOUR].includes(ev.type));
+            .filter((ev: EventType) => [INTERVENTION, INTERNAL_HOUR, UNAVAILABILITY].includes(ev.type));
 
           if (isActive) setEvents(ascendingSortArray(filteredEvents, 'startDate'));
         } catch (e) {


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] J'ai ajouté une variable d'environnement -np
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] Mes changements entrainent une incompatibilité avec l'ancienne version de l'api -np
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : auxiliaire

- Cas d'usage : Sur l'agenda, je vois les indisponibilités.

- Comment tester ? : 
   - ajouter une indisponibilité dans le planning de l'auxiliaire
   - se connecter ETQ auxiliaire et vérifier que l'indisponibilité apparait dans le planning

Rmq: En testant je me suis rendu compte d'un bug sur iOS, en cliquant sur le dateTimePicker de n'importe quel évènement (intervention ou indispo) celui ci apparait mais n'a pas de couleur donc il est invisible.

![Image d’iOS-2](https://user-images.githubusercontent.com/81675019/172405433-7e10d12f-2fe0-4fd4-922d-5ee1a51a2312.png)


 J'ai donc ajouté une couleur pour qu'il apparaisse correctement sur iOS : https://www.npmjs.com/package/@react-native-community/datetimepicker#textColor-optional-ios-only 
Je ne comprends pas pourquoi ce pb n'apparait que maintenant car nous n'avons pas maj le paquet mais j'ai trouvé un moyen de le résoudre.

_Si tu as lu cette description, pense a réagir avec un :eye:_
