### PR TITLE
COM-2762 - add padding on android

### DIFF
--- a/src/components/ToastMessage/styles.ts
+++ b/src/components/ToastMessage/styles.ts
@@ -1,4 +1,4 @@
-import { StyleSheet, Platform } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { WHITE } from '../../styles/colors';
 import { FIRA_SANS_MEDIUM } from '../../styles/fonts';
 import { BORDER_RADIUS, MARGIN, PADDING, SCREEN_HEIGHT } from '../../styles/metrics';
@@ -8,8 +8,7 @@ type ToastMessageStyleProps = {
 };
 
 const TOAST_MESSAGE_HEIGHT = 56;
-const iosOffset = Platform.OS === 'ios' ? MARGIN.MD : 0;
-const TOAST_OFFSET = TOAST_MESSAGE_HEIGHT + MARGIN.MD + iosOffset;
+const TOAST_OFFSET = TOAST_MESSAGE_HEIGHT + MARGIN.XL;
 const TOAST_POSITION = SCREEN_HEIGHT - TOAST_OFFSET;
 
 const styles = ({ backgroundColor } : ToastMessageStyleProps) => StyleSheet.create({


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] Mes changements entrainent une incompatibilité avec l'ancienne version de l'api
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : ETQ auxiliaire

- Cas d'usage : Lorsque j'édite la fiche d'un beneficiaire, un toast-message apparait.

- Comment tester ? :
- modifier la fiche d'un beneficiaire puis enregistrer
- verifier que le toast message est visible

_Si tu as lu cette description, pense a réagir avec un :eye:_
