### PR TITLE
COM-2939: remove deprecated function

### DIFF
--- a/src/context/AuthContext.ts
+++ b/src/context/AuthContext.ts
@@ -4,7 +4,6 @@ import createAuthContext, { StateType, ActionType } from './createAuthContext';
 import Authentication from '../api/Authentication';
 import Users from '../api/Users';
 import asyncStorage from '../core/helpers/asyncStorage';
-import CompaniDate from '../core/helpers/dates/companiDates';
 
 const authReducer = (state: StateType, action: ActionType) => {
   switch (action.type) {
@@ -58,22 +57,6 @@ const refreshCompaniToken = (dispatch: React.Dispatch<ActionType>) => async (ref
   }
 };
 
-// ensures the transition of token from stringedJSDate to CompaniDate. To be removed in march 2022 or after.
-const getTokenFromAsyncStorageAndReset = async () => {
-  const { refreshToken, refreshTokenExpireDate } = await asyncStorage.getRefreshToken();
-  if (!refreshToken || !refreshTokenExpireDate) return { refreshToken, refreshTokenExpireDate };
-
-  try {
-    CompaniDate(refreshTokenExpireDate).toISO(); // throw error if date is stringedJSDate
-
-    return { refreshToken, refreshTokenExpireDate };
-  } catch {
-    await asyncStorage.setRefreshToken(refreshToken);
-
-    return asyncStorage.getRefreshToken();
-  }
-};
-
 const tryLocalSignIn = (dispatch: React.Dispatch<ActionType>) => async () => {
   try {
     const { companiToken, companiTokenExpireDate } = await asyncStorage.getCompaniToken();
@@ -81,7 +64,7 @@ const tryLocalSignIn = (dispatch: React.Dispatch<ActionType>) => async () => {
     if (asyncStorage.isTokenValid(companiToken, companiTokenExpireDate)) {
       dispatch({ type: 'signIn', payload: companiToken });
     } else {
-      const { refreshToken, refreshTokenExpireDate } = await getTokenFromAsyncStorageAndReset();
+      const { refreshToken, refreshTokenExpireDate } = await asyncStorage.getRefreshToken();
 
       if (asyncStorage.isTokenValid(refreshToken, refreshTokenExpireDate)) {
         await refreshCompaniToken(dispatch)(refreshToken);


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] ~~Mes changements entrainent une incompatibilité avec l'ancienne version de l'api~~
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : mobile outils - auxiliaire

- Cas d'usage : suppression de la fonction pour fixer le refreshToken, retour à l'ancienne gestion

- Comment tester ? :
  - passer  `if (asyncStorage.isTokenValid(companiToken, companiTokenExpireDate))` à `if (false)` pour rentrer dans le else
  - se connecter et fermer l’app
  - re-ouvrir l’app => je suis bien connecté

_Si tu as lu cette description, pense a réagir avec un :eye:_
