### PR TITLE
COM-2931: refacto colors

### DIFF
--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -1,9 +1,3 @@
-export const WHITE = 'white';
-export const MODAL_BACKDROP_GREY = '#00000099';
-export const TRANSPARENT_COPPER = 'rgba(71, 96, 105, 0.2)';
-export const SHADOW_COPPER = 'rgb(206, 225, 229)';
-export const RED = '#FF0000';
-
 export const COPPER_GREY = {
   50: '#F9FBFB',
   100: '#F3F6F7',
@@ -33,7 +27,7 @@ export const ORANGE = {
   200: '#FEE7C8',
   300: '#FBC88D',
   400: '#F6A555',
-  500: '#F6A555',
+  500: '#ED8936',
   600: '#DD6B20',
   700: '#C05621',
   800: '#9C4221',
@@ -52,3 +46,9 @@ export const GREEN = {
   800: '#276749',
   900: '#22543D',
 };
+
+export const WHITE = 'white';
+export const MODAL_BACKDROP_GREY = '#00000099';
+export const TRANSPARENT_COPPER = 'rgba(71, 96, 105, 0.2)';
+export const RED = '#FF0000';
+export const SHADOW_COPPER = COPPER_GREY[300];


### PR DESCRIPTION
### TESTS  :computer:

- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) ce qu'il fallait mettre à jour
- [ ] ~~Mes changements entrainent une incompatibilité avec l'ancienne version de l'api~~
  - [ ] Si oui, j'ai noté dans le [slite de déploiement](https://alenvi.slite.com/app/channels/K4ziWiq5eN/notes/qSsdyBwQsC) qu'il faut fusionner l'api dans staging avant d'envoyer le build

---

### POUR TESTER LA PR  :white_check_mark:
- Périmètre interfaces / rôles : tous

- Cas d'usage : refacto des couleurs
vu avec Romain : 
- on implémente orange plutôt que new-orange 
- on conserve peach100 et 200 même s'ils sont pas dans figma
- orange-50 vaut new-orange-50

- Comment tester ? : s'assurer que les ombres s'affichent bien

_Si tu as lu cette description, pense a réagir avec un :eye:_
